### PR TITLE
[refactor]: handleApiError 표준 에러 핸들링 도입 및 레거시 제거

### DIFF
--- a/app/api/category/[categoryId]/header/route.ts
+++ b/app/api/category/[categoryId]/header/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCategoryHeader } from '@/app/apis/service/category/headerService'
+import { handleApiError, createNotFoundError, createServiceError } from '@/app/apis/base'
 
 export async function GET(
   request: NextRequest,
@@ -9,13 +10,12 @@ export async function GET(
 
   try {
     const result = await getCategoryHeader(categoryId)
-    if ('error' in result) return NextResponse.json({ error: result.error }, { status: result.status })
+    if ('error' in result) {
+      if (result.status === 404) throw createNotFoundError(result.error)
+      throw createServiceError(result.error)
+    }
     return NextResponse.json(result)
   } catch (err) {
-    console.error("Unexpected error fetching mates:", err);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return handleApiError(err)
   }
 }

--- a/app/api/category/[categoryId]/mate/route.ts
+++ b/app/api/category/[categoryId]/mate/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import type { MatesApiResponse } from "@/app/category/_types/categoryPage.types";
 import { getCategoryMates } from '@/app/apis/service/category/mateService'
-import { toErrorResponse, BadRequestError } from '@/app/apis/base'
+import { handleApiError, createBadRequestError } from '@/app/apis/base'
 
 // 페이지 크기 및 쿼리 결과 타입은 Service로 이동
 
@@ -15,7 +15,7 @@ export async function GET(
   const page = parseInt(searchParams.get("page") ?? "0", 10);
 
   if (!categoryId || isNaN(page) || page < 0) {
-    throw new BadRequestError("Invalid category ID or page number");
+    throw createBadRequestError("Invalid category ID or page number");
   }
 
   try {
@@ -23,7 +23,7 @@ export async function GET(
     const response: MatesApiResponse = result
     return NextResponse.json(response)
   } catch (err) {
-    return toErrorResponse(err)
+    return handleApiError(err)
   }
 }
 

--- a/app/api/category/popular/route.ts
+++ b/app/api/category/popular/route.ts
@@ -4,7 +4,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
-import { toErrorResponse, BadRequestError, ServiceError } from '@/app/apis/base'
+import { handleApiError, createBadRequestError, createServiceError } from '@/app/apis/base'
 
 import { Database } from "@/types/database.types";
 import type { PopularGame } from "@/app/category/_api/CategoryApi";
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
   const limit = limitParam ? parseInt(limitParam, 10) : 6; // 기본 6개
 
   if (isNaN(limit) || limit < 1 || limit > 20) {
-    throw new BadRequestError("Invalid limit parameter (1-20)");
+    throw createBadRequestError("Invalid limit parameter (1-20)");
   }
 
   const cookieStore = await cookies();
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
       .limit(limit);
 
     if (popularError) {
-      throw new ServiceError('Failed to fetch popular games', popularError);
+      throw createServiceError('Failed to fetch popular games', popularError);
     }
 
     const latestGames = (popularGamesRaw as unknown as RecommendedGamesLatestRow[] | null) ?? [];
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest) {
       .in("id", gameIds);
 
     if (gamesError) {
-      throw new ServiceError('Failed to fetch game details', gamesError);
+      throw createServiceError('Failed to fetch game details', gamesError);
     }
 
     // 3) player_count와 함께 게임 정보 병합, 순서 보장
@@ -106,6 +106,6 @@ export async function GET(request: NextRequest) {
       games: popularGames,
     });
   } catch (error) {
-    return toErrorResponse(error)
+    return handleApiError(error)
   }
 }

--- a/app/api/category/route.ts
+++ b/app/api/category/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getCategoryList } from '@/app/apis/service/category/listService'
-import { toErrorResponse, BadRequestError } from '@/app/apis/base'
+import { handleApiError, createBadRequestError } from '@/app/apis/base'
 
 // 첫 로드시 로드할 아이템 수, 이후 페이지당 게임 카테고리를 로드할 아이템 수
 const INITIAL_LOAD = 18
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
   const page = parseInt(raw, 10)
 
   if (isNaN(page) || page < 0) {
-    throw new BadRequestError('Invalid page number')
+    throw createBadRequestError('Invalid page number')
   }
 
   // 페이지별 limit/offset 계산
@@ -27,6 +27,6 @@ export async function GET(request: NextRequest) {
     const result = await getCategoryList(page)
     return NextResponse.json(result)
   } catch (err) {
-    return toErrorResponse(err)
+    return handleApiError(err)
   }
 }

--- a/app/api/mate/partner/route.ts
+++ b/app/api/mate/partner/route.ts
@@ -2,13 +2,13 @@
 
 import { NextResponse } from 'next/server'
 import { getPartnerMates } from '@/app/apis/service/mate/recommendService'
+import { handleApiError } from '@/app/apis/base'
 
 export async function GET() {
   try {
     const partnerMates = await getPartnerMates(4)
     return NextResponse.json(partnerMates)
   } catch (error) {
-    console.error('API Error:', error)
-    return NextResponse.json({ error: '파트너 메이트 정보를 가져오는데 실패했습니다.' }, { status: 500 })
+    return handleApiError(error)
   }
 }

--- a/app/api/mate/recommend/route.ts
+++ b/app/api/mate/recommend/route.ts
@@ -2,13 +2,13 @@
 
 import { NextResponse } from 'next/server'
 import { getSimpleRecommendedMates } from '@/app/apis/service/mate/recommendService'
+import { handleApiError } from '@/app/apis/base'
 
 export async function GET() {
   try {
     const recommended = await getSimpleRecommendedMates(5)
     return NextResponse.json(recommended)
   } catch (error) {
-    console.error('API Error:', error)
-    return NextResponse.json({ error: '추천 메이트 정보를 가져오는데 실패했습니다.' }, { status: 500 })
+    return handleApiError(error)
   }
 }

--- a/app/api/notifications/mark-all-read/route.ts
+++ b/app/api/notifications/mark-all-read/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 
 import { createServerClientComponent } from '@/supabase/functions/server'
+import { handleApiError, createUnauthorizedError, createServiceError } from '@/app/apis/base'
 
 export async function POST() {
   try {
@@ -11,10 +12,7 @@ export async function POST() {
     const { data: { user }, error: authError } = await supabase.auth.getUser()
 
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      )
+      throw createUnauthorizedError('로그인이 필요합니다')
     }
 
     // 모든 알림 읽음 처리
@@ -25,20 +23,12 @@ export async function POST() {
       .eq('is_read', false)
 
     if (error) {
-      console.error('모든 알림 읽음 처리 실패:', error)
-      return NextResponse.json(
-        { error: 'Failed to mark all notifications as read' },
-        { status: 500 }
-      )
+      throw createServiceError('모든 알림 읽음 처리 실패', error)
     }
 
     return NextResponse.json({ success: true })
 
   } catch (error) {
-    console.error('모든 알림 읽음 처리 API 에러:', error)
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    return handleApiError(error)
   }
 }

--- a/app/api/notifications/mark-header-read/route.ts
+++ b/app/api/notifications/mark-header-read/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 
 import { createServerClientComponent } from '@/supabase/functions/server'
+import { handleApiError, createUnauthorizedError, createServiceError } from '@/app/apis/base'
 
 export async function POST() {
   try {
@@ -11,10 +12,7 @@ export async function POST() {
     const { data: { user }, error: authError } = await supabase.auth.getUser()
 
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      )
+      throw createUnauthorizedError('로그인이 필요합니다')
     }
 
     // 헤더에 표시되는 일반 알림 읽음 처리 (메시지, 의뢰 관련 제외)
@@ -35,20 +33,12 @@ export async function POST() {
     const { error } = await query
 
     if (error) {
-      console.error('헤더 알림 읽음 처리 실패:', error)
-      return NextResponse.json(
-        { error: 'Failed to mark header notifications as read' },
-        { status: 500 }
-      )
+      throw createServiceError('헤더 알림 읽음 처리 실패', error)
     }
 
     return NextResponse.json({ success: true })
 
   } catch (error) {
-    console.error('헤더 알림 읽음 처리 API 에러:', error)
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    return handleApiError(error)
   }
 }

--- a/app/api/notifications/mark-read/route.ts
+++ b/app/api/notifications/mark-read/route.ts
@@ -1,6 +1,7 @@
 // app/api/notifications/mark-read/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerClientComponent } from '@/supabase/functions/server'
+import { handleApiError, createUnauthorizedError, createServiceError } from '@/app/apis/base'
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,10 +12,7 @@ export async function POST(request: NextRequest) {
     const { data: { user }, error: authError } = await supabase.auth.getUser()
 
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      )
+      throw createUnauthorizedError('로그인이 필요합니다')
     }
 
     // 알림 읽음 처리
@@ -25,20 +23,12 @@ export async function POST(request: NextRequest) {
       .eq('user_id', user.id) // 보안을 위해 사용자 ID 확인
 
     if (error) {
-      console.error('알림 읽음 처리 실패:', error)
-      return NextResponse.json(
-        { error: 'Failed to mark notification as read' },
-        { status: 500 }
-      )
+      throw createServiceError('알림 읽음 처리 실패', error)
     }
 
     return NextResponse.json({ success: true })
 
   } catch (error) {
-    console.error('알림 읽음 처리 API 에러:', error)
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    return handleApiError(error)
   }
 }

--- a/app/api/notifications/mark-task-read/route.ts
+++ b/app/api/notifications/mark-task-read/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 
 import { createServerClientComponent } from '@/supabase/functions/server'
+import { handleApiError, createUnauthorizedError, createServiceError } from '@/app/apis/base'
 
 export async function POST() {
   try {
@@ -11,10 +12,7 @@ export async function POST() {
     const { data: { user }, error: authError } = await supabase.auth.getUser()
 
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      )
+      throw createUnauthorizedError('로그인이 필요합니다')
     }
 
     // 의뢰 관련 알림 읽음 처리
@@ -26,20 +24,12 @@ export async function POST() {
       .in('type', ['request', 'accept', 'reject', 'cancel', 'complete'])
 
     if (error) {
-      console.error('태스크 알림 읽음 처리 실패:', error)
-      return NextResponse.json(
-        { error: 'Failed to mark task notifications as read' },
-        { status: 500 }
-      )
+      throw createServiceError('태스크 알림 읽음 처리 실패', error)
     }
 
     return NextResponse.json({ success: true })
 
   } catch (error) {
-    console.error('태스크 알림 읽음 처리 API 에러:', error)
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    return handleApiError(error)
   }
 }

--- a/app/api/order/provider-reservations/route.ts
+++ b/app/api/order/provider-reservations/route.ts
@@ -1,6 +1,7 @@
 // app/api/order/provider-reservations/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { getMyProviderReservations } from '@/app/apis/service/order/providerReservationsService'
+import { handleApiError, createServiceError } from '@/app/apis/base'
 
 export async function GET(request: NextRequest) {
   try {
@@ -8,10 +9,6 @@ export async function GET(request: NextRequest) {
     const result = await getMyProviderReservations(providerId ?? undefined)
     return NextResponse.json(result)
   } catch (error) {
-    console.error('예약 정보 조회 오류:', error)
-    return NextResponse.json(
-      { error: '예약 정보를 가져오는데 실패했습니다.' },
-      { status: 500 }
-    )
+    return handleApiError(createServiceError('예약 정보 조회 오류', error))
   }
 }

--- a/app/api/order/received/route.ts
+++ b/app/api/order/received/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getMyReceivedOrders } from '@/app/apis/service/order/receivedService'
+import { handleApiError, createServiceError } from '@/app/apis/base'
 
 // GET: 사용자가 받은 의뢰 목록 조회
 export async function GET(request: NextRequest) {
@@ -8,10 +9,6 @@ export async function GET(request: NextRequest) {
     const result = await getMyReceivedOrders({ status: statusParam })
     return NextResponse.json(result)
   } catch (error) {
-    console.error('의뢰 목록 조회 오류:', error)
-    return NextResponse.json(
-      { error: '의뢰 목록을 가져오는데 실패했습니다.' },
-      { status: 500 }
-    )
+    return handleApiError(createServiceError('의뢰 목록 조회 오류', error))
   }
 }

--- a/app/api/order/requested/route.ts
+++ b/app/api/order/requested/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { NextRequest } from 'next/server'
 import { getMyRequestedOrders } from '@/app/apis/service/order/requestedService'
+import { handleApiError, createServiceError } from '@/app/apis/base'
 
 // GET: 사용자가 신청한 의뢰 목록 조회 (리뷰 작성 여부 포함)
 export async function GET(request: NextRequest) {
@@ -9,11 +10,6 @@ export async function GET(request: NextRequest) {
     const result = await getMyRequestedOrders({ status: statusParam ?? undefined })
     return NextResponse.json(result)
   } catch (error) {
-    console.error('신청한 의뢰 목록 조회 오류:', error)
-    const message = error instanceof Error ? error.message : '알 수 없는 오류 발생'
-    return NextResponse.json(
-      { error: '의뢰 목록을 가져오는데 실패했습니다: ' + message },
-      { status: 500 }
-    )
+    return handleApiError(createServiceError('신청한 의뢰 목록 조회 오류', error))
   }
 }

--- a/app/api/order/status/route.ts
+++ b/app/api/order/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { changeOrderStatus } from '@/app/apis/service/order/statusService'
+import { handleApiError, createServiceError } from '@/app/apis/base'
 
 // PATCH: 의뢰 상태 변경
 export async function PATCH(request: Request) {
@@ -8,11 +9,6 @@ export async function PATCH(request: Request) {
     const result = await changeOrderStatus(body)
     return NextResponse.json(result)
   } catch (error) {
-    console.error(`[API /api/order/status] Error processing PATCH request:`, error);
-    const errorMessage = error instanceof Error ? error.message : '알 수 없는 오류 발생'
-    return NextResponse.json(
-      { error: '의뢰 상태 변경 중 예기치 않은 오류가 발생했습니다: ' + errorMessage },
-      { status: 500 }
-    )
+    return handleApiError(createServiceError('의뢰 상태 변경 중 오류', error))
   }
-} 
+}

--- a/app/api/order/verify/route.ts
+++ b/app/api/order/verify/route.ts
@@ -1,15 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getMessagesAndMarkRead, createOrderWithPayment } from '@/app/apis/service/order/verifyService'
-import { toErrorResponse, BadRequestError } from '@/app/apis/base'
+import { handleApiError, createBadRequestError } from '@/app/apis/base'
 
 export async function GET(request: NextRequest) {
   try {
     const roomId = request.nextUrl.searchParams.get('roomId')
-    if (!roomId) throw new BadRequestError('채팅방 ID가 필요합니다')
+    if (!roomId) throw createBadRequestError('채팅방 ID가 필요합니다')
     const result = await getMessagesAndMarkRead(roomId)
     return NextResponse.json(result)
   } catch (error) {
-    return toErrorResponse(error)
+    return handleApiError(error)
   }
 }
 
@@ -18,12 +18,12 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const { providerId, game, scheduledDate, scheduledTime, price } = body ?? {}
     if (!providerId || !game || !scheduledDate || !scheduledTime || typeof price !== 'number') {
-      throw new BadRequestError('필수 정보가 누락되었습니다.')
+      throw createBadRequestError('필수 정보가 누락되었습니다.')
     }
     const result = await createOrderWithPayment({ providerId, game, scheduledDate, scheduledTime, price })
     return NextResponse.json(result)
   } catch (error) {
-    return toErrorResponse(error)
+    return handleApiError(error)
   }
 }
 

--- a/app/api/payment/verify/route.ts
+++ b/app/api/payment/verify/route.ts
@@ -1,14 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAndChargeTokens } from '@/app/apis/service/payment/verifyService'
+import { handleApiError, createBadRequestError, createServiceError } from '@/app/apis/base'
 
 export async function GET(request: NextRequest) {
   try {
     const paymentId = request.nextUrl.searchParams.get('paymentId')
-    const secret = process.env.PORTONE_V2_API_SECRET!
-    const result = await verifyAndChargeTokens(paymentId || '', secret)
+    if (!paymentId) {
+      throw createBadRequestError('paymentId is required')
+    }
+    const secret = process.env.PORTONE_V2_API_SECRET
+    if (!secret) {
+      throw createServiceError('Payment secret not configured')
+    }
+    const result = await verifyAndChargeTokens(paymentId, secret)
     return NextResponse.json(result)
   } catch (error) {
-    const message = error instanceof Error ? error.message : '알 수 없는 서버 오류가 발생했습니다'
-    return NextResponse.json({ success: false, message }, { status: 500 })
+    return handleApiError(error)
   }
 }

--- a/app/api/profile/image/image_gallery/route.ts
+++ b/app/api/profile/image/image_gallery/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getAlbumGallery, uploadAlbumImage, deleteAlbumImage, setThumbnail } from "@/app/apis/service/profile/albumService";
-import { toErrorResponse, UnauthorizedError, BadRequestError } from "@/app/apis/base";
+import { handleApiError, createUnauthorizedError, createBadRequestError } from "@/app/apis/base";
 
 // GET: 앨범 이미지 목록 조회
 export async function GET() {
@@ -11,10 +11,10 @@ export async function GET() {
   } catch (error: any) {
     if (typeof error?.message === 'string') {
       if (error.message === '사용자 인증 오류') {
-        return toErrorResponse(new UnauthorizedError(error.message));
+        return handleApiError(createUnauthorizedError(error.message));
       }
     }
-    return toErrorResponse(error);
+    return handleApiError(error);
   }
 }
 
@@ -28,13 +28,13 @@ export async function POST(request: Request) {
   } catch (error: any) {
     if (typeof error?.message === 'string') {
       if (error.message === '사용자 인증 오류') {
-        return toErrorResponse(new UnauthorizedError(error.message));
+        return handleApiError(createUnauthorizedError(error.message));
       }
       if (error.message.includes('필수 정보') || error.message.includes('인덱스')) {
-        return toErrorResponse(new BadRequestError(error.message));
+        return handleApiError(createBadRequestError(error.message));
       }
     }
-    return toErrorResponse(error);
+    return handleApiError(error);
   }
 }
 
@@ -42,17 +42,17 @@ export async function POST(request: Request) {
 export async function DELETE(request: Request) {
   try {
     const { imageId } = await request.json();
-    if (!imageId) throw new BadRequestError('이미지 ID가 누락되었습니다.');
+    if (!imageId) throw createBadRequestError('이미지 ID가 누락되었습니다.');
     const result = await deleteAlbumImage(imageId);
     return NextResponse.json({ success: true, ...result });
 
   } catch (error: any) {
     if (typeof error?.message === 'string') {
       if (error.message === '사용자 인증 오류') {
-        return toErrorResponse(new UnauthorizedError(error.message));
+        return handleApiError(createUnauthorizedError(error.message));
       }
     }
-    return toErrorResponse(error);
+    return handleApiError(error);
   }
 }
 
@@ -60,16 +60,16 @@ export async function DELETE(request: Request) {
 export async function PATCH(request: Request) {
   try {
     const { imageUrl } = await request.json();
-    if (!imageUrl) throw new BadRequestError('URL이 누락되었습니다.');
+    if (!imageUrl) throw createBadRequestError('URL이 누락되었습니다.');
     const result = await setThumbnail(imageUrl);
     return NextResponse.json({ success: true, ...result });
 
   } catch (error: any) {
     if (typeof error?.message === 'string') {
       if (error.message === '사용자 인증 오류') {
-        return toErrorResponse(new UnauthorizedError(error.message));
+        return handleApiError(createUnauthorizedError(error.message));
       }
     }
-    return toErrorResponse(error);
+    return handleApiError(error);
   }
 }

--- a/app/api/profile/image/profileImage/route.ts
+++ b/app/api/profile/image/profileImage/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 
 import { Database } from "@/types/database.types";
-import { toErrorResponse, UnauthorizedError, BadRequestError, ServiceError } from "@/app/apis/base";
+import { handleApiError, createUnauthorizedError, createBadRequestError, createServiceError } from "@/app/apis/base";
 
 // 프로필 이미지 정보 가져오기
 export async function GET() {
@@ -29,7 +29,7 @@ export async function GET() {
     const { data: { user } } = await supabase.auth.getUser();
     
     if (!user) {
-      throw new UnauthorizedError("사용자 인증 오류");
+      throw createUnauthorizedError("사용자 인증 오류");
     }
 
     const { data, error } = await supabase
@@ -39,7 +39,7 @@ export async function GET() {
       .single();
     
     if (error) {
-      throw new ServiceError('프로필 이미지 조회 실패', error);
+      throw createServiceError('프로필 이미지 조회 실패', error);
     }
 
     return NextResponse.json({ 
@@ -50,7 +50,7 @@ export async function GET() {
       }
     });
   } catch (error) {
-    return toErrorResponse(error);
+    return handleApiError(error);
   }
 }
 
@@ -77,13 +77,13 @@ export async function POST(request: Request) {
     const { data: { user } } = await supabase.auth.getUser();
     
     if (!user) {
-      throw new UnauthorizedError("사용자 인증 오류");
+      throw createUnauthorizedError("사용자 인증 오류");
     }
 
     const { imageUrl } = await request.json();
 
     if (!imageUrl) {
-      throw new BadRequestError("이미지 URL이 제공되지 않았습니다");
+      throw createBadRequestError("이미지 URL이 제공되지 않았습니다");
     }
 
     // 사용자 정보 업데이트
@@ -97,7 +97,7 @@ export async function POST(request: Request) {
       .eq("id", user.id);
 
     if (error) {
-      throw new ServiceError('프로필 이미지 업데이트 실패', error);
+      throw createServiceError('프로필 이미지 업데이트 실패', error);
     }
 
     return NextResponse.json({ 
@@ -105,6 +105,6 @@ export async function POST(request: Request) {
       data: { imageUrl } 
     });
   } catch (error) {
-    return toErrorResponse(error);
+    return handleApiError(error);
   }
 }

--- a/app/api/profile/info/route.ts
+++ b/app/api/profile/info/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 import { getProfileInfo, updateProfileInfo } from '@/app/apis/service/profile/infoService'
-import { toErrorResponse, BadRequestError, ValidationError } from '@/app/apis/base'
+import { handleApiError, createBadRequestError, createValidationError } from '@/app/apis/base'
 
 export async function GET() {
   try {
     const result = await getProfileInfo()
     return NextResponse.json(result)
   } catch (error) {
-    return toErrorResponse(error)
+    return handleApiError(error)
   }
 }
 
@@ -16,13 +16,13 @@ export async function POST(request: Request) {
     const requestData = await request.json()
     const result = await updateProfileInfo(requestData)
     if ('status' in result && result.status === 400) {
-      throw new ValidationError(result.error, result.details)
+      throw createValidationError(result.error, result.details)
     }
     return NextResponse.json(result)
   } catch (error: any) {
     if (error instanceof SyntaxError) {
-      return toErrorResponse(new BadRequestError('잘못된 요청 형식입니다.'))
+      return handleApiError(createBadRequestError('잘못된 요청 형식입니다.'))
     }
-    return toErrorResponse(error)
+    return handleApiError(error)
   }
 }

--- a/app/api/profile/public/route.ts
+++ b/app/api/profile/public/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerClientComponent } from '@/supabase/functions/server'
+import { handleApiError, createBadRequestError, createNotFoundError } from '@/app/apis/base'
 
 export async function GET(req: NextRequest) {
   try {
@@ -8,7 +9,7 @@ export async function GET(req: NextRequest) {
     const publicId = Number(publicIdParam)
 
     if (!publicIdParam || Number.isNaN(publicId)) {
-      return NextResponse.json({ error: 'Invalid publicId' }, { status: 400 })
+      throw createBadRequestError('Invalid publicId')
     }
 
     const supabase = await createServerClientComponent()
@@ -20,7 +21,7 @@ export async function GET(req: NextRequest) {
       .single()
 
     if (profileError || !profileInfo || !profileInfo.user_id) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+      throw createNotFoundError('Profile not found')
     }
 
     const { data: userInfo, error: userError } = await supabase
@@ -30,7 +31,7 @@ export async function GET(req: NextRequest) {
       .single()
 
     if (userError || !userInfo) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+      throw createNotFoundError('User not found')
     }
 
     const data = {
@@ -42,8 +43,7 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ data }, { status: 200 })
   } catch (err) {
-    console.error('[GET /api/profile/public] error:', err)
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    return handleApiError(err)
   }
 }
 

--- a/app/api/profile/review/route.ts
+++ b/app/api/profile/review/route.ts
@@ -1,21 +1,21 @@
 import { NextResponse, NextRequest } from 'next/server'
 import { getProfileReviewsByPublicId } from '@/app/apis/service/profile/reviewService'
+import { handleApiError, createBadRequestError } from '@/app/apis/base'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const publicProfileIdString = searchParams.get('profileId')
   if (!publicProfileIdString) {
-    return NextResponse.json({ error: 'Profile ID is required' }, { status: 400 })
+    throw createBadRequestError('Profile ID is required')
   }
   const publicProfileId = Number(publicProfileIdString)
   if (isNaN(publicProfileId)) {
-    return NextResponse.json({ error: 'Invalid Profile ID format' }, { status: 400 })
+    throw createBadRequestError('Invalid Profile ID format')
   }
   try {
     const result = await getProfileReviewsByPublicId(publicProfileId)
     return NextResponse.json(result, { status: 200 })
   } catch (error: any) {
-    console.error('[API Review] Unexpected error:', error)
-    return NextResponse.json({ error: 'Internal Server Error', details: error.message }, { status: 500 })
+    return handleApiError(error)
   }
 }

--- a/app/api/storage/upload/route.ts
+++ b/app/api/storage/upload/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { uploadMyAvatar } from '@/app/apis/service/storage/uploadService'
-import { toErrorResponse, BadRequestError } from '@/app/apis/base'
+import { handleApiError, createBadRequestError } from '@/app/apis/base'
 
 export async function POST(request: Request) {
   try {
@@ -8,20 +8,20 @@ export async function POST(request: Request) {
     const file = formData.get('file') as File
 
     if (!file) {
-      throw new BadRequestError("파일이 제공되지 않았습니다")
+      throw createBadRequestError("파일이 제공되지 않았습니다")
     }
 
     if (!file.type.startsWith('image/')) {
-      throw new BadRequestError("이미지 파일만 업로드할 수 있습니다")
+      throw createBadRequestError("이미지 파일만 업로드할 수 있습니다")
     }
 
     if (file.size > 5 * 1024 * 1024) {
-      throw new BadRequestError("파일 크기는 5MB를 초과할 수 없습니다")
+      throw createBadRequestError("파일 크기는 5MB를 초과할 수 없습니다")
     }
 
     const result = await uploadMyAvatar(file)
     return NextResponse.json(result)
   } catch (error) {
-    return toErrorResponse(error)
+    return handleApiError(error)
   }
 }

--- a/app/api/tasks/refund/route.ts
+++ b/app/api/tasks/refund/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { refundTokens } from '@/app/apis/service/tasks/refundService'
+import { handleApiError, createServiceError } from '@/app/apis/base'
 
 export async function POST(request: Request) {
   try {
@@ -7,10 +8,6 @@ export async function POST(request: Request) {
     const result = await refundTokens({ requestId, amount })
     return NextResponse.json(result)
   } catch (error) {
-    console.error('토큰 반환 중 오류 발생:', error)
-    return NextResponse.json(
-      { error: '토큰 반환에 실패했습니다.' },
-      { status: 500 }
-    )
+    return handleApiError(createServiceError('토큰 반환 중 오류 발생', error))
   }
-}   
+}

--- a/app/api/tasks/review/route.ts
+++ b/app/api/tasks/review/route.ts
@@ -1,22 +1,21 @@
 import { NextResponse } from 'next/server'
 import { createReview } from '@/app/apis/service/tasks/reviewService'
+import { handleApiError, createBadRequestError } from '@/app/apis/base'
 
 // POST: 새 리뷰 생성
 export async function POST(request: Request) {
   try {
     const { rating, content, requestId, reviewedId } = await request.json()
     if (rating === null || rating < 1 || rating > 5) {
-      return NextResponse.json({ error: '유효하지 않은 평점입니다.' }, { status: 400 })
+      throw createBadRequestError('유효하지 않은 평점입니다.')
     }
     if (!requestId || !reviewedId) {
-      return NextResponse.json({ error: '필수 정보 누락 (의뢰 ID 또는 리뷰 대상 ID)' }, { status: 400 })
+      throw createBadRequestError('필수 정보 누락 (의뢰 ID 또는 리뷰 대상 ID)')
     }
     const result = await createReview({ rating, content, requestId, reviewedId })
     return NextResponse.json(result)
   } catch (error) {
-    console.error('리뷰 생성 API 오류:', error)
-    const message = error instanceof Error ? error.message : '알 수 없는 오류 발생'
-    return NextResponse.json({ error: '리뷰 처리 중 예기치 않은 오류 발생: ' + message }, { status: 500 })
+    return handleApiError(error)
   }
 }
 

--- a/app/api/token/balance/route.ts
+++ b/app/api/token/balance/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server'
 
 import { getMyTokenBalance } from '@/app/apis/service/token/balanceService'
-import { toErrorResponse } from '@/app/apis/base'
+import { handleApiError } from '@/app/apis/base'
 
 export async function GET() {
   try {
     const result = await getMyTokenBalance()
     return NextResponse.json(result)
   } catch (error) {
-    return toErrorResponse(error)
+    return handleApiError(error)
   }
 }

--- a/app/api/token/detailUsage/route.ts
+++ b/app/api/token/detailUsage/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
+import { handleApiError, createGoneError } from '@/app/apis/base'
 
 export async function GET() {
-  const res = NextResponse.json(
-    { success: false, code: 'GONE', message: "/api/token/detailUsage is removed. Use /api/token/transactions." },
-    { status: 410 }
-  )
-  res.headers.set('X-Deprecated-Endpoint', '/api/token/detailUsage is removed; use /api/token/transactions')
-  res.headers.set('Link', '</api/token/transactions>; rel="successor-version"')
-  return res
+  try {
+    throw createGoneError('/api/token/detailUsage is removed. Use /api/token/transactions.')
+  } catch (error) {
+    const res = handleApiError(error)
+    res.headers.set('X-Deprecated-Endpoint', '/api/token/detailUsage is removed; use /api/token/transactions')
+    res.headers.set('Link', '</api/token/transactions>; rel="successor-version"')
+    return res
+  }
 }

--- a/app/api/token/transactions/route.ts
+++ b/app/api/token/transactions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getMyTokenTransactions } from '@/app/apis/service/token/transactionsService'
-import { toErrorResponse } from '@/app/apis/base'
+import { handleApiError } from '@/app/apis/base'
 
 export async function GET(request: NextRequest) {
   try {
@@ -25,6 +25,6 @@ export async function GET(request: NextRequest) {
       },
     })
   } catch (error) {
-    return toErrorResponse(error)
+    return handleApiError(error)
   }
 }

--- a/app/api/token/variation/route.ts
+++ b/app/api/token/variation/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import { getMyMonthlyUsage } from '@/app/apis/service/token/variationService'
-import { toErrorResponse } from '@/app/apis/base'
+import { handleApiError } from '@/app/apis/base'
 
 export async function GET() {
   try {
     const result = await getMyMonthlyUsage()
     return NextResponse.json(result)
   } catch (error) {
-    return toErrorResponse(error)
+    return handleApiError(error)
   }
 }

--- a/app/apis/base/auth.ts
+++ b/app/apis/base/auth.ts
@@ -1,11 +1,11 @@
 'use server'
 import { getServerSupabase } from './client'
-import { UnauthorizedError } from './errors'
+import { createUnauthorizedError } from './errors'
 
 export async function getCurrentUserId(): Promise<string> {
   const supabase = await getServerSupabase()
   const { data: { user }, error } = await supabase.auth.getUser()
-  if (error || !user) throw new UnauthorizedError('사용자 인증 오류')
+  if (error || !user) throw createUnauthorizedError('사용자 인증 오류')
   return user.id
 }
 

--- a/app/apis/base/errors.ts
+++ b/app/apis/base/errors.ts
@@ -1,67 +1,84 @@
 import 'server-only'
 
-export class RepositoryError extends Error {
-  constructor(public readonly context: string, public readonly cause?: unknown) {
-    super(`[Repository] ${context}`)
-  }
+// 함수형 에러 생성 함수들
+export function createRepositoryError(context: string, cause?: unknown): Error {
+  const error = new Error(`[Repository] ${context}`)
+  error.name = 'RepositoryError'
+  ;(error as any).cause = cause
+  return error
 }
 
-export class ServiceError extends Error {
-  constructor(public readonly context: string, public readonly cause?: unknown) {
-    super(`[Service] ${context}`)
-  }
+export function createServiceError(context: string, cause?: unknown): Error {
+  const error = new Error(`[Service] ${context}`)
+  error.name = 'ServiceError'
+  ;(error as any).cause = cause
+  return error
 }
 
-export class UnauthorizedError extends Error {
-  constructor(message = 'Unauthorized') {
-    super(message)
-    this.name = 'UnauthorizedError'
-  }
+export function createUnauthorizedError(message = 'Unauthorized'): Error {
+  const error = new Error(message)
+  error.name = 'UnauthorizedError'
+  return error
 }
 
-export class ForbiddenError extends Error {
-  constructor(message = 'Forbidden') {
-    super(message)
-    this.name = 'ForbiddenError'
-  }
+export function createForbiddenError(message = 'Forbidden'): Error {
+  const error = new Error(message)
+  error.name = 'ForbiddenError'
+  return error
 }
 
-export class BadRequestError extends Error {
-  constructor(message = 'Bad Request') {
-    super(message)
-    this.name = 'BadRequestError'
-  }
+export function createBadRequestError(message = 'Bad Request'): Error {
+  const error = new Error(message)
+  error.name = 'BadRequestError'
+  return error
 }
 
-export class NotFoundError extends Error {
-  constructor(message = 'Not Found') {
-    super(message)
-    this.name = 'NotFoundError'
-  }
+export function createNotFoundError(message = 'Not Found'): Error {
+  const error = new Error(message)
+  error.name = 'NotFoundError'
+  return error
 }
 
-export class ConflictError extends Error {
-  constructor(message = 'Conflict') {
-    super(message)
-    this.name = 'ConflictError'
-  }
+export function createGoneError(message = 'Gone'): Error {
+  const error = new Error(message)
+  error.name = 'GoneError'
+  return error
 }
 
-export class ValidationError extends Error {
-  constructor(
-    message = 'Validation Error',
-    public readonly details?: Record<string, string[]>
-  ) {
-    super(message)
-    this.name = 'ValidationError'
-  }
+export function createConflictError(message = 'Conflict'): Error {
+  const error = new Error(message)
+  error.name = 'ConflictError'
+  return error
+}
+
+export function createValidationError(
+  message = 'Validation Error',
+  details?: Record<string, string[]>
+): Error {
+  const error = new Error(message)
+  error.name = 'ValidationError'
+  ;(error as any).details = details
+  return error
+}
+
+// 타입 가드 함수들
+export function isRepositoryError(error: unknown): error is Error & { cause?: unknown } {
+  return error instanceof Error && error.name === 'RepositoryError'
+}
+
+export function isServiceError(error: unknown): error is Error & { cause?: unknown } {
+  return error instanceof Error && error.name === 'ServiceError'
+}
+
+export function isValidationError(error: unknown): error is Error & { details?: Record<string, string[]> } {
+  return error instanceof Error && error.name === 'ValidationError'
 }
 
 export async function wrapRepo<T>(context: string, fn: () => Promise<T>): Promise<T> {
   try {
     return await fn()
   } catch (e) {
-    throw new RepositoryError(context, e)
+    throw createRepositoryError(context, e)
   }
 }
 
@@ -69,7 +86,7 @@ export async function wrapService<T>(context: string, fn: () => Promise<T>): Pro
   try {
     return await fn()
   } catch (e) {
-    throw new ServiceError(context, e)
+    throw createServiceError(context, e)
   }
 }
 

--- a/app/apis/base/http.ts
+++ b/app/apis/base/http.ts
@@ -1,79 +1,72 @@
 import 'server-only'
 
 import { NextResponse } from 'next/server'
-import {
-  BadRequestError,
-  ConflictError,
-  ForbiddenError,
-  NotFoundError,
-  RepositoryError,
-  ServiceError,
-  UnauthorizedError,
-  ValidationError,
-} from './errors'
+import { isValidationError } from './errors'
 
-function codeOf(err: Error): string {
-  switch (err.name) {
-    case 'UnauthorizedError':
-      return 'UNAUTHORIZED'
-    case 'ForbiddenError':
-      return 'FORBIDDEN'
-    case 'BadRequestError':
-      return 'BAD_REQUEST'
-    case 'NotFoundError':
-      return 'NOT_FOUND'
-    case 'ConflictError':
-      return 'CONFLICT'
-    case 'ValidationError':
-      return 'VALIDATION_ERROR'
-    case 'RepositoryError':
-    case 'ServiceError':
-      return 'INTERNAL_SERVER_ERROR'
-    default:
-      return 'INTERNAL_SERVER_ERROR'
+function getErrorCode(errorName: string): string {
+  const codeMap: Record<string, string> = {
+    'UnauthorizedError': 'UNAUTHORIZED',
+    'ForbiddenError': 'FORBIDDEN',
+    'BadRequestError': 'BAD_REQUEST',
+    'NotFoundError': 'NOT_FOUND',
+    'GoneError': 'GONE',
+    'ConflictError': 'CONFLICT',
+    'ValidationError': 'VALIDATION_ERROR',
+    'RepositoryError': 'INTERNAL_SERVER_ERROR',
+    'ServiceError': 'INTERNAL_SERVER_ERROR',
   }
+  return codeMap[errorName] ?? 'INTERNAL_SERVER_ERROR'
 }
 
-function statusOf(err: Error): number {
-  if (err instanceof UnauthorizedError) return 401
-  if (err instanceof ForbiddenError) return 403
-  if (err instanceof BadRequestError) return 400
-  if (err instanceof NotFoundError) return 404
-  if (err instanceof ConflictError) return 409
-  if (err instanceof ValidationError) return 400
-  return 500
+function getStatusCode(errorName: string): number {
+  const statusMap: Record<string, number> = {
+    'UnauthorizedError': 401,
+    'ForbiddenError': 403,
+    'BadRequestError': 400,
+    'NotFoundError': 404,
+    'GoneError': 410,
+    'ConflictError': 409,
+    'ValidationError': 400,
+    'RepositoryError': 500,
+    'ServiceError': 500,
+  }
+  return statusMap[errorName] ?? 500
 }
 
-export function toErrorResponse(e: unknown): NextResponse {
-  const isError = e instanceof Error
-  const err = isError ? (e as Error) : new Error('Unknown error')
-  const status = statusOf(err)
-  const code = codeOf(err)
+export function handleApiError(error: unknown): NextResponse {
+  if (!(error instanceof Error)) {
+    return NextResponse.json(
+      {
+        success: false,
+        code: 'INTERNAL_SERVER_ERROR',
+        message: '알 수 없는 오류가 발생했습니다',
+      },
+      { status: 500 }
+    )
+  }
 
-  const base = {
+  const status = getStatusCode(error.name)
+  const code = getErrorCode(error.name)
+  const isClientError = status < 500
+
+  const response: any = {
     success: false,
     code,
-    // 보안상 상세 메시지 노출 최소화. 도메인 에러는 메시지 사용.
-    message:
-      err instanceof BadRequestError ||
-      err instanceof UnauthorizedError ||
-      err instanceof ForbiddenError ||
-      err instanceof NotFoundError ||
-      err instanceof ConflictError ||
-      err instanceof ValidationError
-        ? err.message
-        : '서버 오류가 발생했습니다.',
-  } as any
-
-  if (err instanceof ValidationError && err.details) {
-    base.details = err.details
+    message: isClientError ? error.message : '서버 오류가 발생했습니다',
   }
 
-  // 최소한의 서버 로그
-  // RepositoryError/ServiceError 등은 내부 cause만 로그, 응답에는 노출하지 않음
+  // ValidationError의 details 추가
+  if (isValidationError(error) && error.details) {
+    response.details = error.details
+  }
+
+  // 개발 환경에서만 상세 로그
   if (process.env.NODE_ENV !== 'production') {
-    console.error('[API_ERROR]', err.name, err.message)
+    console.error('[API_ERROR]', error.name, error.message)
+    if ((error as any).cause) {
+      console.error('[API_ERROR_CAUSE]', (error as any).cause)
+    }
   }
 
-  return NextResponse.json(base, { status })
+  return NextResponse.json(response, { status })
 }

--- a/app/apis/base/index.ts
+++ b/app/apis/base/index.ts
@@ -1,7 +1,31 @@
+// 클라이언트 관련
 export * from './client'
+
+// 페이징 관련
 export * from './pagination'
-export * from './errors'
-export * from './http'
+
+// 에러 처리 관련
+export {
+  createBadRequestError,
+  createUnauthorizedError,
+  createForbiddenError,
+  createNotFoundError,
+  createGoneError,
+  createConflictError,
+  createValidationError,
+  createRepositoryError,
+  createServiceError,
+  isRepositoryError,
+  isServiceError,
+  isValidationError,
+  wrapRepo,
+  wrapService
+} from './errors'
+
+// HTTP 응답 처리
+export { handleApiError } from './http'
+
+// RPC 관련
 export * from './rpc'
 
 


### PR DESCRIPTION
- 함수형 에러 생성자 + handleApiError로 라우트 전반 표준화

- 수동 NextResponse 에러/console.error/toErrorResponse 제거

- 검증 로직 try-catch 내 정리, 불필요 임포트/타입 정리

- base 레이어 갱신 및 tableRepo.ts 삭제

- 문서 업데이트 및 FE 호환성 확인 메모

Affects: category/*, chat/*, mate/*, notifications/*, order/*, payment/verify, profile/*, storage/upload, tasks/*, token/*