### PR TITLE
[refactor] : API 라우트 에러 처리 표준화에 따른 서버 Zod 스키마 적용

### DIFF
--- a/app/api/category/[categoryId]/mate/route.ts
+++ b/app/api/category/[categoryId]/mate/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 
 import type { MatesApiResponse } from "@/app/category/_types/categoryPage.types";
 import { getCategoryMates } from '@/app/apis/service/category/mateService'
-import { handleApiError, createBadRequestError } from '@/app/apis/base'
+import { handleApiError, createValidationError } from '@/app/apis/base'
+import { categoryMatesParamsSchema, categoryMatesGetQuerySchema } from '@/libs/schemas/server/category.schema'
 
 // 페이지 크기 및 쿼리 결과 타입은 Service로 이동
 
@@ -10,13 +11,20 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ categoryId: string }> }
 ) {
-  const { categoryId } = await params; // 예: "League_of_legend"
-  const searchParams = request.nextUrl.searchParams;
-  const page = parseInt(searchParams.get("page") ?? "0", 10);
-
-  if (!categoryId || isNaN(page) || page < 0) {
-    throw createBadRequestError("Invalid category ID or page number");
+  const rawParams = await params
+  const paramsParsed = categoryMatesParamsSchema.safeParse(rawParams)
+  if (!paramsParsed.success) {
+    const details = paramsParsed.error.flatten().fieldErrors
+    throw createValidationError('요청 경로 파라미터가 유효하지 않습니다.', details)
   }
+  const { categoryId } = paramsParsed.data
+  const rawQuery = Object.fromEntries(request.nextUrl.searchParams)
+  const queryParsed = categoryMatesGetQuerySchema.safeParse(rawQuery)
+  if (!queryParsed.success) {
+    const details = queryParsed.error.flatten().fieldErrors
+    throw createValidationError('요청 파라미터가 유효하지 않습니다.', details)
+  }
+  const { page } = queryParsed.data
 
   try {
     const result = await getCategoryMates(categoryId, page)

--- a/app/api/category/route.ts
+++ b/app/api/category/route.ts
@@ -1,20 +1,21 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getCategoryList } from '@/app/apis/service/category/listService'
-import { handleApiError, createBadRequestError } from '@/app/apis/base'
+import { handleApiError, createValidationError } from '@/app/apis/base'
+import { categoryListGetQuerySchema } from '@/libs/schemas/server/category.schema'
 
 // 첫 로드시 로드할 아이템 수, 이후 페이지당 게임 카테고리를 로드할 아이템 수
 const INITIAL_LOAD = 18
 const LOAD_PER_PAGE = 12
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url)
-  const raw = searchParams.get('page') ?? '0'
-  const page = parseInt(raw, 10)
-
-  if (isNaN(page) || page < 0) {
-    throw createBadRequestError('Invalid page number')
+  const rawQuery = Object.fromEntries(new URL(request.url).searchParams)
+  const parsed = categoryListGetQuerySchema.safeParse(rawQuery)
+  if (!parsed.success) {
+    const details = parsed.error.flatten().fieldErrors
+    throw createValidationError('요청 파라미터가 유효하지 않습니다.', details)
   }
+  const { page } = parsed.data
 
   // 페이지별 limit/offset 계산
   const limit = page === 0 ? INITIAL_LOAD : LOAD_PER_PAGE

--- a/app/api/notifications/mark-chat-read/route.ts
+++ b/app/api/notifications/mark-chat-read/route.ts
@@ -2,11 +2,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { createServerClientComponent } from '@/supabase/functions/server'
-import { handleApiError, createUnauthorizedError, createServiceError } from '@/app/apis/base'
+import { handleApiError, createUnauthorizedError, createServiceError, createValidationError } from '@/app/apis/base'
+import { markChatReadPostBodySchema } from '@/libs/schemas/server/notification.schema'
 
 export async function POST(request: NextRequest) {
   try {
-    const { chatRoomId } = await request.json()
+    const json = await request.json()
+    const parsed = markChatReadPostBodySchema.safeParse(json)
+    if (!parsed.success) {
+      throw createValidationError('요청 바디가 유효하지 않습니다.', parsed.error.flatten().fieldErrors)
+    }
+    const { chatRoomId } = parsed.data
     const supabase = await createServerClientComponent()
 
     // 현재 사용자 확인

--- a/app/api/notifications/subscribe/route.ts
+++ b/app/api/notifications/subscribe/route.ts
@@ -1,62 +1,70 @@
 // app/api/notifications/subscribe/route.ts
 import { NextRequest } from 'next/server'
+import { handleApiError, createUnauthorizedError, createServiceError } from '@/app/apis/base'
 
 import { createServerClientComponent } from '@/supabase/functions/server'
 
 export async function GET(request: NextRequest) {
-  const encoder = new TextEncoder()
+  try {
+    const supabase = await createServerClientComponent()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
 
-  // ReadableStream을 사용한 Server-Sent Events
-  const stream = new ReadableStream({
-    start(controller) {
-      ;(async () => {
-        try {
-          const supabase = await createServerClientComponent()
-
-          // 현재 사용자 확인
-          const { data: { user }, error: authError } = await supabase.auth.getUser()
-
-          if (authError || !user) {
-            controller.error(new Error('Unauthorized'))
-            return
-          }
-
-          // 실시간 알림 구독
-          const subscription = supabase
-            .channel(`notifications:${user.id}`)
-            .on('postgres_changes',
-              {
-                event: 'INSERT',
-                schema: 'public',
-                table: 'notifications',
-                filter: `user_id=eq.${user.id}`
-              },
-              () => {
-                // 알림 업데이트 이벤트 전송
-                const message = `data: notification_update\n\n`
-                controller.enqueue(encoder.encode(message))
-              }
-            )
-            .subscribe()
-
-          // 연결 종료 시 정리
-          request.signal.addEventListener('abort', () => {
-            supabase.removeChannel(subscription)
-            controller.close()
-          })
-
-        } catch (error) {
-          controller.error(error)
-        }
-      })()
+    if (authError || !user) {
+      return handleApiError(createUnauthorizedError('로그인이 필요합니다.'))
     }
-  })
 
-  return new Response(stream, {
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      'Connection': 'keep-alive',
-    },
-  })
+    const encoder = new TextEncoder()
+
+    // ReadableStream을 사용한 Server-Sent Events
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        ;(async () => {
+          try {
+            // 실시간 알림 구독
+            const subscription = supabase
+              .channel(`notifications:${user.id}`)
+              .on('postgres_changes',
+                {
+                  event: 'INSERT',
+                  schema: 'public',
+                  table: 'notifications',
+                  filter: `user_id=eq.${user.id}`
+                },
+                () => {
+                  // 알림 업데이트 이벤트 전송
+                  const message = `data: notification_update\n\n`
+                  controller.enqueue(encoder.encode(message))
+                }
+              )
+              .subscribe()
+
+            // 주기적 keep-alive 코멘트 전송 (프록시/로드밸런서 타임아웃 방지)
+            const keepAlive = setInterval(() => {
+              controller.enqueue(encoder.encode(`: keepalive\n\n`))
+            }, 15000)
+
+            // 연결 종료 시 정리
+            request.signal.addEventListener('abort', () => {
+              try { supabase.removeChannel(subscription) } catch {}
+              clearInterval(keepAlive)
+              controller.close()
+            })
+          } catch (e) {
+            controller.error(e)
+          }
+        })()
+      }
+    })
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-transform',
+        'Connection': 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    })
+  } catch (error) {
+    return handleApiError(createServiceError('SSE 구독 초기화 실패', error))
+  }
 }

--- a/app/api/order/provider-reservations/route.ts
+++ b/app/api/order/provider-reservations/route.ts
@@ -1,12 +1,18 @@
 // app/api/order/provider-reservations/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { getMyProviderReservations } from '@/app/apis/service/order/providerReservationsService'
-import { handleApiError, createServiceError } from '@/app/apis/base'
+import { handleApiError, createServiceError, createValidationError } from '@/app/apis/base'
+import { providerReservationsGetQuerySchema } from '@/libs/schemas/server/order.schema'
 
 export async function GET(request: NextRequest) {
   try {
-    const providerId = request.nextUrl.searchParams.get('providerId') ?? undefined
-    const result = await getMyProviderReservations(providerId ?? undefined)
+    const rawQuery = { providerId: request.nextUrl.searchParams.get('providerId') ?? undefined }
+    const parsed = providerReservationsGetQuerySchema.safeParse(rawQuery)
+    if (!parsed.success) {
+      throw createValidationError('쿼리 파라미터가 유효하지 않습니다.', parsed.error.flatten().fieldErrors)
+    }
+    const { providerId } = parsed.data
+    const result = await getMyProviderReservations(providerId)
     return NextResponse.json(result)
   } catch (error) {
     return handleApiError(createServiceError('예약 정보 조회 오류', error))

--- a/app/api/order/received/route.ts
+++ b/app/api/order/received/route.ts
@@ -1,12 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getMyReceivedOrders } from '@/app/apis/service/order/receivedService'
-import { handleApiError, createServiceError } from '@/app/apis/base'
+import { handleApiError, createServiceError, createValidationError } from '@/app/apis/base'
+import { orderListQuerySchema } from '@/libs/schemas/server/order.schema'
 
 // GET: 사용자가 받은 의뢰 목록 조회
 export async function GET(request: NextRequest) {
   try {
-    const statusParam = request.nextUrl.searchParams.get('status') ?? undefined
-    const result = await getMyReceivedOrders({ status: statusParam })
+    const rawQuery = { status: request.nextUrl.searchParams.get('status') ?? undefined }
+    const parsed = orderListQuerySchema.safeParse(rawQuery)
+    if (!parsed.success) {
+      throw createValidationError('쿼리 파라미터가 유효하지 않습니다.', parsed.error.flatten().fieldErrors)
+    }
+    const { status } = parsed.data
+    const result = await getMyReceivedOrders({ status })
     return NextResponse.json(result)
   } catch (error) {
     return handleApiError(createServiceError('의뢰 목록 조회 오류', error))

--- a/app/api/order/requested/route.ts
+++ b/app/api/order/requested/route.ts
@@ -1,13 +1,19 @@
 import { NextResponse } from 'next/server'
 import { NextRequest } from 'next/server'
 import { getMyRequestedOrders } from '@/app/apis/service/order/requestedService'
-import { handleApiError, createServiceError } from '@/app/apis/base'
+import { handleApiError, createServiceError, createValidationError } from '@/app/apis/base'
+import { orderListQuerySchema } from '@/libs/schemas/server/order.schema'
 
 // GET: 사용자가 신청한 의뢰 목록 조회 (리뷰 작성 여부 포함)
 export async function GET(request: NextRequest) {
   try {
-    const statusParam = request.nextUrl.searchParams.get('status') ?? undefined
-    const result = await getMyRequestedOrders({ status: statusParam ?? undefined })
+    const rawQuery = { status: request.nextUrl.searchParams.get('status') ?? undefined }
+    const parsed = orderListQuerySchema.safeParse(rawQuery)
+    if (!parsed.success) {
+      throw createValidationError('쿼리 파라미터가 유효하지 않습니다.', parsed.error.flatten().fieldErrors)
+    }
+    const { status } = parsed.data
+    const result = await getMyRequestedOrders({ status })
     return NextResponse.json(result)
   } catch (error) {
     return handleApiError(createServiceError('신청한 의뢰 목록 조회 오류', error))

--- a/app/api/order/status/route.ts
+++ b/app/api/order/status/route.ts
@@ -1,12 +1,17 @@
 import { NextResponse } from 'next/server'
 import { changeOrderStatus } from '@/app/apis/service/order/statusService'
-import { handleApiError, createServiceError } from '@/app/apis/base'
+import { handleApiError, createServiceError, createValidationError } from '@/app/apis/base'
+import { changeOrderStatusBodySchema } from '@/libs/schemas/server/order.schema'
 
 // PATCH: 의뢰 상태 변경
 export async function PATCH(request: Request) {
   try {
-    const body = await request.json()
-    const result = await changeOrderStatus(body)
+    const json = await request.json()
+    const parsed = changeOrderStatusBodySchema.safeParse(json)
+    if (!parsed.success) {
+      throw createValidationError('요청 바디가 유효하지 않습니다.', parsed.error.flatten().fieldErrors)
+    }
+    const result = await changeOrderStatus(parsed.data)
     return NextResponse.json(result)
   } catch (error) {
     return handleApiError(createServiceError('의뢰 상태 변경 중 오류', error))

--- a/app/api/order/verify/route.ts
+++ b/app/api/order/verify/route.ts
@@ -1,11 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getMessagesAndMarkRead, createOrderWithPayment } from '@/app/apis/service/order/verifyService'
-import { handleApiError, createBadRequestError } from '@/app/apis/base'
+import { handleApiError, createValidationError } from '@/app/apis/base'
+import { verifyOrderGetQuerySchema, verifyOrderPostBodySchema } from '@/libs/schemas/server/order.schema'
 
 export async function GET(request: NextRequest) {
   try {
-    const roomId = request.nextUrl.searchParams.get('roomId')
-    if (!roomId) throw createBadRequestError('채팅방 ID가 필요합니다')
+    const rawQuery = Object.fromEntries(request.nextUrl.searchParams)
+    const parsed = verifyOrderGetQuerySchema.safeParse(rawQuery)
+    if (!parsed.success) {
+      const details = parsed.error.flatten().fieldErrors
+      throw createValidationError('요청 파라미터가 유효하지 않습니다.', details)
+    }
+    const { roomId } = parsed.data
     const result = await getMessagesAndMarkRead(roomId)
     return NextResponse.json(result)
   } catch (error) {
@@ -15,12 +21,13 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json()
-    const { providerId, game, scheduledDate, scheduledTime, price } = body ?? {}
-    if (!providerId || !game || !scheduledDate || !scheduledTime || typeof price !== 'number') {
-      throw createBadRequestError('필수 정보가 누락되었습니다.')
+    const body = await request.json().catch(() => undefined)
+    const parsed = verifyOrderPostBodySchema.safeParse(body)
+    if (!parsed.success) {
+      const details = parsed.error.flatten().fieldErrors
+      throw createValidationError('요청 본문이 유효하지 않습니다.', details)
     }
-    const result = await createOrderWithPayment({ providerId, game, scheduledDate, scheduledTime, price })
+    const result = await createOrderWithPayment(parsed.data)
     return NextResponse.json(result)
   } catch (error) {
     return handleApiError(error)

--- a/app/api/payment/verify/route.ts
+++ b/app/api/payment/verify/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAndChargeTokens } from '@/app/apis/service/payment/verifyService'
-import { handleApiError, createBadRequestError, createServiceError } from '@/app/apis/base'
+import { handleApiError, createValidationError, createServiceError } from '@/app/apis/base'
+import { paymentVerifyGetQuerySchema } from '@/libs/schemas/server/payment.schema'
 
 export async function GET(request: NextRequest) {
   try {
-    const paymentId = request.nextUrl.searchParams.get('paymentId')
-    if (!paymentId) {
-      throw createBadRequestError('paymentId is required')
+    const rawQuery = Object.fromEntries(request.nextUrl.searchParams)
+    const parsed = paymentVerifyGetQuerySchema.safeParse(rawQuery)
+    if (!parsed.success) {
+      const details = parsed.error.flatten().fieldErrors
+      throw createValidationError('요청 파라미터가 유효하지 않습니다.', details)
     }
+    const { paymentId } = parsed.data
     const secret = process.env.PORTONE_V2_API_SECRET
     if (!secret) {
       throw createServiceError('Payment secret not configured')

--- a/app/api/storage/upload/route.ts
+++ b/app/api/storage/upload/route.ts
@@ -1,24 +1,17 @@
 import { NextResponse } from "next/server";
 import { uploadMyAvatar } from '@/app/apis/service/storage/uploadService'
-import { handleApiError, createBadRequestError } from '@/app/apis/base'
+import { handleApiError, createValidationError } from '@/app/apis/base'
+import { avatarUploadFormDataSchema } from '@/libs/schemas/server/upload.schema'
 
 export async function POST(request: Request) {
   try {
     const formData = await request.formData()
-    const file = formData.get('file') as File
-
-    if (!file) {
-      throw createBadRequestError("파일이 제공되지 않았습니다")
+    const parsed = avatarUploadFormDataSchema.safeParse({ file: formData.get('file') })
+    if (!parsed.success) {
+      const details = parsed.error.flatten().fieldErrors
+      throw createValidationError('요청 본문이 유효하지 않습니다.', details)
     }
-
-    if (!file.type.startsWith('image/')) {
-      throw createBadRequestError("이미지 파일만 업로드할 수 있습니다")
-    }
-
-    if (file.size > 5 * 1024 * 1024) {
-      throw createBadRequestError("파일 크기는 5MB를 초과할 수 없습니다")
-    }
-
+    const { file } = parsed.data
     const result = await uploadMyAvatar(file)
     return NextResponse.json(result)
   } catch (error) {

--- a/app/api/tasks/refund/route.ts
+++ b/app/api/tasks/refund/route.ts
@@ -1,11 +1,16 @@
 import { NextResponse } from 'next/server'
 import { refundTokens } from '@/app/apis/service/tasks/refundService'
-import { handleApiError, createServiceError } from '@/app/apis/base'
+import { handleApiError, createServiceError, createValidationError } from '@/app/apis/base'
+import { refundTokensPostBodySchema } from '@/libs/schemas/server/tasks.schema'
 
 export async function POST(request: Request) {
   try {
-    const { requestId, amount } = await request.json()
-    const result = await refundTokens({ requestId, amount })
+    const json = await request.json()
+    const parsed = refundTokensPostBodySchema.safeParse(json)
+    if (!parsed.success) {
+      throw createValidationError('요청 바디가 유효하지 않습니다.', parsed.error.flatten().fieldErrors)
+    }
+    const result = await refundTokens(parsed.data)
     return NextResponse.json(result)
   } catch (error) {
     return handleApiError(createServiceError('토큰 반환 중 오류 발생', error))

--- a/libs/schemas/server/album.schema.ts
+++ b/libs/schemas/server/album.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+// POST /api/profile/image/image_gallery (form-data)
+export const albumUploadFormDataSchema = z.object({
+  file: z
+    .instanceof(File, { message: 'file은 필수입니다.' })
+    .refine((f) => f.type?.startsWith('image/'), { message: '이미지 파일만 업로드할 수 있습니다.' })
+    .refine((f) => f.size <= 5 * 1024 * 1024, { message: '파일 크기는 5MB를 초과할 수 없습니다.' }),
+  index: z.coerce
+    .number({ invalid_type_error: 'index는 숫자여야 합니다.' })
+    .int({ message: 'index는 정수여야 합니다.' })
+    .min(0, { message: 'index는 0 이상이어야 합니다.' })
+    .max(5, { message: 'index는 5 이하여야 합니다.' }),
+})
+
+// DELETE /api/profile/image/image_gallery
+export const albumDeleteBodySchema = z.object({
+  imageId: z
+    .string({ required_error: 'imageId는 필수입니다.' })
+    .min(1, { message: 'imageId는 비어 있을 수 없습니다.' })
+})
+
+// PATCH /api/profile/image/image_gallery
+export const albumSetThumbnailBodySchema = z.object({
+  imageUrl: z
+    .string({ required_error: 'imageUrl은 필수입니다.' })
+    .min(1, { message: 'imageUrl은 비어 있을 수 없습니다.' })
+})
+
+export type AlbumUploadFormData = z.infer<typeof albumUploadFormDataSchema>
+export type AlbumDeleteBody = z.infer<typeof albumDeleteBodySchema>
+export type AlbumSetThumbnailBody = z.infer<typeof albumSetThumbnailBodySchema>

--- a/libs/schemas/server/category.schema.ts
+++ b/libs/schemas/server/category.schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+// GET /api/category/popular?limit=...
+export const categoryPopularGetQuerySchema = z.object({
+  limit: z.coerce
+    .number({ invalid_type_error: 'limit은 숫자여야 합니다.' })
+    .int({ message: 'limit은 정수여야 합니다.' })
+    .min(1, { message: 'limit은 최소 1입니다.' })
+    .max(20, { message: 'limit은 최대 20입니다.' })
+    .default(6),
+})
+
+// GET /api/category?page=...
+export const categoryListGetQuerySchema = z.object({
+  page: z.coerce
+    .number({ invalid_type_error: 'page는 숫자여야 합니다.' })
+    .int({ message: 'page는 정수여야 합니다.' })
+    .min(0, { message: 'page는 0 이상의 값이어야 합니다.' })
+    .default(0),
+})
+
+// GET /api/category/[categoryId]/mate?page=...
+export const categoryMatesParamsSchema = z.object({
+  categoryId: z
+    .string({ required_error: 'categoryId는 필수입니다.' })
+    .min(1, { message: 'categoryId는 비어 있을 수 없습니다.' }),
+})
+
+export const categoryMatesGetQuerySchema = z.object({
+  page: z.coerce
+    .number({ invalid_type_error: 'page는 숫자여야 합니다.' })
+    .int({ message: 'page는 정수여야 합니다.' })
+    .min(0, { message: 'page는 0 이상의 값이어야 합니다.' })
+    .default(0),
+})
+
+export type CategoryPopularGetQuery = z.infer<typeof categoryPopularGetQuerySchema>
+export type CategoryListGetQuery = z.infer<typeof categoryListGetQuerySchema>
+export type CategoryMatesParams = z.infer<typeof categoryMatesParamsSchema>
+export type CategoryMatesGetQuery = z.infer<typeof categoryMatesGetQuerySchema>

--- a/libs/schemas/server/chat.schema.ts
+++ b/libs/schemas/server/chat.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+// params for GET /api/chat/room/[roomId]
+export const chatRoomParamsSchema = z.object({
+  roomId: z
+    .string({ required_error: 'roomId는 필수입니다.' })
+    .min(1, { message: 'roomId는 비어 있을 수 없습니다.' })
+})
+
+export type ChatRoomParams = z.infer<typeof chatRoomParamsSchema>
+ 
+ // params for POST /api/chat/users/[userId]/chat
+ export const chatUserParamsSchema = z.object({
+   userId: z
+     .string({ required_error: 'userId는 필수입니다.' })
+     .min(1, { message: 'userId는 비어 있을 수 없습니다.' })
+ })

--- a/libs/schemas/server/messages.schema.ts
+++ b/libs/schemas/server/messages.schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+export const chatMessagesGetQuerySchema = z.object({
+  roomId: z
+    .string({ required_error: 'roomId는 필수입니다.' })
+    .min(1, { message: 'roomId는 비어 있을 수 없습니다.' })
+})
+
+export const sendMessageBodySchema = z.object({
+  content: z
+    .string({ required_error: 'content는 필수입니다.' })
+    .trim()
+    .min(1, { message: '메시지 내용은 비어 있을 수 없습니다.' })
+    .max(2000, { message: '메시지 내용은 2000자를 초과할 수 없습니다.' }),
+  receiverId: z
+    .string({ required_error: 'receiverId는 필수입니다.' })
+    .min(1, { message: 'receiverId는 비어 있을 수 없습니다.' }),
+  chatRoomId: z
+    .string()
+    .min(1, { message: 'chatRoomId는 비어 있을 수 없습니다.' })
+    .optional(),
+})
+
+export type ChatMessagesGetQuery = z.infer<typeof chatMessagesGetQuerySchema>
+export type SendMessageBody = z.infer<typeof sendMessageBodySchema>

--- a/libs/schemas/server/notification.schema.ts
+++ b/libs/schemas/server/notification.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+// POST /api/notifications/mark-chat-read
+export const markChatReadPostBodySchema = z.object({
+  chatRoomId: z
+    .string({ required_error: 'chatRoomId는 필수입니다.' })
+    .min(1, { message: 'chatRoomId는 비어 있을 수 없습니다.' })
+})
+export type MarkChatReadPostBody = z.infer<typeof markChatReadPostBodySchema>
+
+// POST /api/notifications/mark-read
+export const markReadPostBodySchema = z.object({
+  notificationId: z
+    .string({ required_error: 'notificationId는 필수입니다.' })
+    .min(1, { message: 'notificationId는 비어 있을 수 없습니다.' })
+})
+export type MarkReadPostBody = z.infer<typeof markReadPostBodySchema>

--- a/libs/schemas/server/order.schema.ts
+++ b/libs/schemas/server/order.schema.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+
+// GET /api/order/verify?roomId=...
+export const verifyOrderGetQuerySchema = z.object({
+  roomId: z
+    .string({ required_error: 'roomId는 필수입니다.' })
+    .min(1, { message: 'roomId는 비어 있을 수 없습니다.' })
+})
+
+// POST /api/order/verify
+// 서비스에서 추가 비즈니스 검증을 수행하므로 여기서는 형식/필수성 위주로 검증합니다.
+export const verifyOrderPostBodySchema = z.object({
+  providerId: z
+    .string({ required_error: 'providerId는 필수입니다.' })
+    .min(1, { message: 'providerId는 비어 있을 수 없습니다.' }),
+  game: z
+    .string({ required_error: 'game은 필수입니다.' })
+    .min(1, { message: 'game은 비어 있을 수 없습니다.' })
+    .max(64, { message: 'game은 64자를 초과할 수 없습니다.' }),
+  // 날짜/시간은 포맷이 다양할 수 있어 우선 비어있지 않음을 확인하고,
+  // 상세 포맷 검증은 서비스 계층 또는 후속 스키마에서 강화합니다.
+  scheduledDate: z
+    .string({ required_error: 'scheduledDate는 필수입니다.' })
+    .min(1, { message: 'scheduledDate는 비어 있을 수 없습니다.' }),
+  scheduledTime: z
+    .string({ required_error: 'scheduledTime는 필수입니다.' })
+    .min(1, { message: 'scheduledTime는 비어 있을 수 없습니다.' }),
+  // price는 문자열로 올 수도 있으므로 전처리로 숫자 변환을 허용합니다.
+  price: z.preprocess((v) => {
+    if (typeof v === 'string' && v.trim() !== '') return Number(v)
+    return v
+  }, z.number({ invalid_type_error: 'price는 숫자여야 합니다.' }).int().nonnegative({ message: 'price는 음수일 수 없습니다.' }))
+})
+
+export type VerifyOrderPostBody = z.infer<typeof verifyOrderPostBodySchema>
+
+// 공통 상태 Enum 및 쿼리/바디 스키마들
+export const orderStatusEnum = z.enum(['pending', 'accepted', 'rejected', 'completed', 'canceled'])
+
+// GET /api/order/received, /api/order/requested
+export const orderListQuerySchema = z.object({
+  status: orderStatusEnum.optional()
+})
+export type OrderListQuery = z.infer<typeof orderListQuerySchema>
+
+// GET /api/order/provider-reservations
+export const providerReservationsGetQuerySchema = z.object({
+  providerId: z.string().min(1, { message: 'providerId는 비어 있을 수 없습니다.' }).optional()
+})
+export type ProviderReservationsGetQuery = z.infer<typeof providerReservationsGetQuerySchema>
+
+// PATCH /api/order/status
+export const changeOrderStatusBodySchema = z.object({
+  requestId: z
+    .string({ required_error: 'requestId는 필수입니다.' })
+    .min(1, { message: 'requestId는 비어 있을 수 없습니다.' }),
+  status: orderStatusEnum
+})
+export type ChangeOrderStatusBody = z.infer<typeof changeOrderStatusBodySchema>

--- a/libs/schemas/server/payment.schema.ts
+++ b/libs/schemas/server/payment.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+// GET /api/payment/verify?paymentId=...
+export const paymentVerifyGetQuerySchema = z.object({
+  paymentId: z
+    .string({ required_error: 'paymentId는 필수입니다.' })
+    .min(1, { message: 'paymentId는 비어 있을 수 없습니다.' })
+})
+
+export type PaymentVerifyGetQuery = z.infer<typeof paymentVerifyGetQuerySchema>

--- a/libs/schemas/server/profile.schema.ts
+++ b/libs/schemas/server/profile.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+// GET /api/profile/public?publicId=...
+export const profilePublicGetQuerySchema = z.object({
+  publicId: z.coerce
+    .number({ invalid_type_error: 'publicId는 숫자여야 합니다.' })
+    .int({ message: 'publicId는 정수여야 합니다.' })
+    .positive({ message: 'publicId는 1 이상의 값이어야 합니다.' })
+})
+
+export type ProfilePublicGetQuery = z.infer<typeof profilePublicGetQuerySchema>
+ 
+ export const profileImageUpdateBodySchema = z.object({
+   imageUrl: z
+     .string({ required_error: 'imageUrl은 필수입니다.' })
+     .min(1, { message: 'imageUrl는 비어 있을 수 없습니다.' })
+ })

--- a/libs/schemas/server/review.schema.ts
+++ b/libs/schemas/server/review.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+// GET /api/profile/review?profileId=...
+export const profileReviewsGetQuerySchema = z.object({
+  profileId: z.coerce
+    .number({ invalid_type_error: 'profileId는 숫자여야 합니다.' })
+    .int({ message: 'profileId는 정수여야 합니다.' })
+    .positive({ message: 'profileId는 1 이상의 값이어야 합니다.' })
+})
+
+// POST /api/tasks/review
+export const createReviewBodySchema = z.object({
+  rating: z.coerce
+    .number({ invalid_type_error: 'rating은 숫자여야 합니다.' })
+    .int({ message: 'rating은 정수여야 합니다.' })
+    .min(1, { message: 'rating은 최소 1입니다.' })
+    .max(5, { message: 'rating은 최대 5입니다.' }),
+  content: z
+    .string()
+    .trim()
+    .max(1000, { message: 'content는 1000자를 초과할 수 없습니다.' })
+    .optional(),
+  requestId: z
+    .string({ required_error: 'requestId는 필수입니다.' })
+    .min(1, { message: 'requestId는 비어 있을 수 없습니다.' }),
+  reviewedId: z
+    .string({ required_error: 'reviewedId는 필수입니다.' })
+    .min(1, { message: 'reviewedId는 비어 있을 수 없습니다.' }),
+})
+
+export type ProfileReviewsGetQuery = z.infer<typeof profileReviewsGetQuerySchema>
+export type CreateReviewBody = z.infer<typeof createReviewBodySchema>

--- a/libs/schemas/server/tasks.schema.ts
+++ b/libs/schemas/server/tasks.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+// POST /api/tasks/refund
+export const refundTokensPostBodySchema = z.object({
+  requestId: z
+    .string({ required_error: 'requestId는 필수입니다.' })
+    .min(1, { message: 'requestId는 비어 있을 수 없습니다.' }),
+  amount: z.preprocess((v) => {
+    if (typeof v === 'string' && v.trim() !== '') return Number(v)
+    return v
+  }, z.number({ invalid_type_error: 'amount는 숫자여야 합니다.' }).int().positive({ message: 'amount는 양수여야 합니다.' }))
+})
+
+export type RefundTokensPostBody = z.infer<typeof refundTokensPostBodySchema>

--- a/libs/schemas/server/upload.schema.ts
+++ b/libs/schemas/server/upload.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+// POST /api/storage/upload (avatar)
+export const avatarUploadFormDataSchema = z.object({
+  file: z
+    .instanceof(File, { message: 'file은 필수이며 File 타입이어야 합니다.' })
+    .refine((f) => f.type?.startsWith('image/'), { message: '이미지 파일만 업로드할 수 있습니다.' })
+    .refine((f) => f.size <= 5 * 1024 * 1024, { message: '파일 크기는 5MB를 초과할 수 없습니다.' }),
+})
+
+export type AvatarUploadFormData = z.infer<typeof avatarUploadFormDataSchema>


### PR DESCRIPTION
Path/Query/Body 입력에 Zod safeParse 도입, fieldErrors → details 맵으로 표준화
Docs/zod-vaildation.md 파일에 입력 검증/정규화/스키마 적용 범위 및 적용 원칙 가이드 작성

- 신규 추가(서버 스키마)

libs/schemas/server/album.schema.ts
libs/schemas/server/category.schema.ts
libs/schemas/server/chat.schema.ts
libs/schemas/server/messages.schema.ts
libs/schemas/server/notification.schema.ts
libs/schemas/server/order.schema.ts
libs/schemas/server/payment.schema.ts
libs/schemas/server/profile.schema.ts
libs/schemas/server/review.schema.ts
libs/schemas/server/tasks.schema.ts
libs/schemas/server/upload.schema.ts

- 수정 라우트

app/api/category/[categoryId]/mate/route.ts
app/api/category/popular/route.ts
app/api/category/route.ts
app/api/chat/messages/route.ts
app/api/chat/room/[roomId]/route.ts
app/api/chat/rooms/[roomId]/read/route.ts
app/api/chat/users/[userId]/chat/route.ts
app/api/notifications/mark-chat-read/route.ts
app/api/notifications/mark-read/route.ts
app/api/order/provider-reservations/route.ts
app/api/order/received/route.ts
app/api/order/requested/route.ts
app/api/order/status/route.ts
app/api/order/verify/route.ts
app/api/payment/verify/route.ts
app/api/profile/image/image_gallery/route.ts
app/api/profile/image/profileImage/route.ts
app/api/profile/public/route.ts
app/api/profile/review/route.ts
app/api/storage/upload/route.ts
app/api/tasks/refund/route.ts
app/api/tasks/review/route.ts