### PR TITLE
 [refactor] : chat page global search state + debounce & setup Prettier/ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,10 +13,17 @@
     "plugin:import/typescript",
     "prettier"
   ],
+  "settings": {
+    "import/resolver": {
+      "typescript": true,
+      "node": true
+    }
+  },
   "rules": {
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/consistent-type-imports": "warn",
 
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
@@ -34,5 +41,23 @@
       "warn",
       { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["stores/**/*.ts", "stores/**/*.tsx"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@/supabase/functions/server",
+                "message": "서버 전용 클라이언트는 client/store에서 사용 금지. 대신 '@/supabase/functions/client' 사용."
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,24 @@
+# Build artifacts
+.next/
+out/
+dist/
+build/
+coverage/
+.turbo/
+.vercel/
+
+# Dependencies
+node_modules/
+
+# OS/editor
+.DS_Store
+.vscode/
+
+# Package managers
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Misc
+logs/
+tmp/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "arrowParens": "always",
+  "semi": false,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "endOfLine": "lf"
+}

--- a/app/dashboard/chat/_components/LeftSection.tsx
+++ b/app/dashboard/chat/_components/LeftSection.tsx
@@ -1,24 +1,18 @@
-'use client'
+"use client"
 
-import { Dispatch, SetStateAction } from "react"
+import type { ReactNode } from "react"
+import { useEffect } from "react"
 
-import SearchChatInput from "./SearchChatInput"
-import ChatList from "./ChatList"
+import { useChatUiStore } from "@/stores/chatUiStore"
 
-interface LeftSectionProps {
-  searchTerm: string;
-  setSearchTerm: Dispatch<SetStateAction<string>>;
+export default function LeftSection({ children }: { children: ReactNode }) {
+  const reset = useChatUiStore((s) => s.reset)
+
+  // 페이지 입장/이탈 시 검색어 초기화
+  useEffect(() => {
+    reset()
+    return () => reset()
+  }, [reset])
+
+  return <div className="w-80 bg-base-100 rounded-lg shadow-xl flex flex-col">{children}</div>
 }
-
-export default function LeftSection({ searchTerm, setSearchTerm }: LeftSectionProps) {
-  const handleSearch = (query: string) => {
-    setSearchTerm(query)
-  }
-
-  return (
-    <div className="w-80 bg-base-100 rounded-lg shadow-xl flex flex-col">
-      <SearchChatInput onSearch={handleSearch} />
-      <ChatList searchTerm={searchTerm} />
-    </div>
-  )
-} 

--- a/app/dashboard/chat/_components/SearchChatInput.tsx
+++ b/app/dashboard/chat/_components/SearchChatInput.tsx
@@ -1,27 +1,34 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import debounce from 'lodash/debounce'
 
-interface SearchChatInputProps {
-  onSearch: (query: string) => void
-}
+import { useChatUiStore } from '@/stores/chatUiStore'
 
-export default function SearchChatInput({ onSearch }: SearchChatInputProps) {
-  const [searchQuery, setSearchQuery] = useState('')
-  const searchInputRef = useRef<HTMLInputElement>(null)
+export default function SearchChatInput() {
+  const [value, setValue] = useState('')
+  const setSearchTerm = useChatUiStore((s) => s.setSearchTerm)
 
-  // 검색어가 변경될 때마다 상위 컴포넌트에 알림
+  // 디바운스된 업데이트 함수 (상태 없이 수행)
+  const debouncedUpdate = useMemo(
+    () => debounce((q: string) => setSearchTerm(q), 250),
+    [setSearchTerm]
+  )
+
   useEffect(() => {
-    // 검색어가 변경될 때마다 바로 검색 실행
-    onSearch(searchQuery)
-  }, [searchQuery, onSearch])
+    return () => debouncedUpdate.cancel()
+  }, [debouncedUpdate])
+
+  const handleChangeValue = (q: string) => {
+    setValue(q)
+    debouncedUpdate(q)
+  }
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
-    // 폼 제출 시에도 검색 실행 (Enter 키)
-    onSearch(searchQuery)
-    // 포커스 유지
-    searchInputRef.current?.focus()
+    // 엔터 시 대기 중인 디바운스 취소 후 즉시 반영
+    debouncedUpdate.cancel()
+    setSearchTerm(value)
   }
 
   return (
@@ -30,14 +37,13 @@ export default function SearchChatInput({ onSearch }: SearchChatInputProps) {
       <div className="form-control">
         <form onSubmit={handleSearch} className="flex input-group">
           <input
-            ref={searchInputRef}
             type="text"
             placeholder="채팅방 검색하기..."
             className="input input-bordered w-full"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            value={value}
+            onChange={(e) => handleChangeValue(e.target.value)}
           />
-          <button type="submit" className="btn btn-square btn-ghost">
+          <button type="submit" className="btn btn-square btn-ghost" aria-label="검색">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               className="h-6 w-6"
@@ -52,9 +58,10 @@ export default function SearchChatInput({ onSearch }: SearchChatInputProps) {
                 d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
               />
             </svg>
+            <span className="sr-only">검색</span>
           </button>
         </form>
       </div>
     </div>
   )
-} 
+}

--- a/app/dashboard/chat/_hooks/ChatPageContainer.tsx
+++ b/app/dashboard/chat/_hooks/ChatPageContainer.tsx
@@ -1,46 +1,25 @@
-'use client'
-
-import { useState } from 'react'
-
-import LeftSection from '../_components/LeftSection'
-import RightSection from '../_components/RightSection'
-import ChatRoom from '../_components/ChatRoom'
+import { type ReactNode } from "react"
 
 interface OtherUser {
-  id: string;
-  name: string;
-  profile_circle_img: string | null;
-  is_online: boolean;
+  id: string
+  name: string
+  profile_circle_img: string | null
+  is_online: boolean
 }
 
 interface ChatRoom {
-  id: string;
-  last_message: string | null;
-  last_message_time: string | null;
+  id: string
+  last_message: string | null
+  last_message_time: string | null
   participants: {
-    id: string;
-    chat_room_id: string;
-    user_id: string;
-    unread_count: number;
-  }[];
-  otherUser: OtherUser | null;
+    id: string
+    chat_room_id: string
+    user_id: string
+    unread_count: number
+  }[]
+  otherUser: OtherUser | null
 }
 
-export default function ChatPageContainer() {
-  const [searchTerm, setSearchTerm] = useState('')
-  
-  return (
-      <div className="flex  h-[calc(100vh-4rem)] gap-4">
-        {/* 왼쪽 섹션: 채팅 리스트 */}
-        <LeftSection 
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
-      />
-      
-      {/* 오른쪽 섹션: 채팅 내용 */}
-      <RightSection>
-          <ChatRoom />
-        </RightSection>
-      </div>
-  )
-} 
+export default function ChatPageContainer({ children }: { children: ReactNode }) {
+  return <div className="flex  h-[calc(100vh-4rem)] gap-4">{children}</div>
+}

--- a/app/dashboard/chat/page.tsx
+++ b/app/dashboard/chat/page.tsx
@@ -1,10 +1,25 @@
 import ChatPageContainer from './_hooks/ChatPageContainer'
-
+import LeftSection from './_components/LeftSection'
+import RightSection from './_components/RightSection'
+import ChatRoom from './_components/ChatRoom'
+import SearchChatInput from './_components/SearchChatInput'
+import ChatList from './_components/ChatList'
 export const metadata = {
   title: '채팅 - Game Mate',
   description: '게임 메이트와 채팅으로 소통하세요',
 }
 
 export default function ChatPage() {
-  return <ChatPageContainer />
-} 
+  return (
+    <ChatPageContainer>
+      <LeftSection >
+        <SearchChatInput />
+         <ChatList />
+      </LeftSection>
+      
+      <RightSection>
+        <ChatRoom />
+      </RightSection>
+    </ChatPageContainer>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,10 +60,12 @@
         "eslint": "^8",
         "eslint-config-next": "15.4.6",
         "eslint-config-prettier": "^10.1.2",
+        "eslint-import-resolver-typescript": "^3.6.3",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-unused-imports": "^4.1.4",
         "postcss": "^8",
+        "prettier": "^3.3.3",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.7.3"
       }
@@ -7563,6 +7565,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proc-log": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:fix": "next lint --fix",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -61,9 +65,11 @@
     "eslint": "^8",
     "eslint-config-next": "15.4.6",
     "eslint-config-prettier": "^10.1.2",
+    "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-unused-imports": "^4.1.4",
+    "prettier": "^3.3.3",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.7.3"

--- a/stores/chatUiStore.ts
+++ b/stores/chatUiStore.ts
@@ -1,0 +1,15 @@
+"use client"
+
+import { create } from 'zustand'
+
+type ChatUiState = {
+  searchTerm: string
+  setSearchTerm: (q: string) => void
+  reset: () => void
+}
+
+export const useChatUiStore = create<ChatUiState>((set) => ({
+  searchTerm: '',
+  setSearchTerm: (q) => set({ searchTerm: q }),
+  reset: () => set({ searchTerm: '' }),
+}))


### PR DESCRIPTION
## Why
- 검색 상태가 컴포넌트 간 분산되어 일관성 저하
- 입력 시 과도한 연산/리렌더
- 포매터/린트가 로컬/CI에서 일관 미보장

## What
- Zustand 전역 검색 상태 도입 및 페이지 입출 시 reset
- Search 입력 디바운스(250ms) + Enter 즉시 반영(cancel 처리)
- Prettier/ESLint 설정 정비(semi: false 등)

## How (Key Changes)
- stores/chatUiStore.ts 추가, LeftSection 입출 시 reset()
- SearchChatInput 디바운스 및 cancel 처리
- ChatList 전역 searchTerm 기반 필터, import 정리
- 포매터/린트 설정 및 스크립트 업데이트

##대상 파일 
- app/dashboard/chat/_components/LeftSection.tsx
- app/dashboard/chat/_components/SearchChatInput.tsx
- app/dashboard/chat/_components/ChatList.tsx
- app/dashboard/chat/_hooks/ChatPageContainer.tsx
- app/dashboard/chat/page.tsx
- stores/chatUiStore.ts
- .eslintrc.json
- .prettierignore
- .prettierrc