### PR TITLE
[refactor] : 대시보드 페이지 리팩터링(컨테이너/콘텐츠 분리, 서버 Suspense 유지) 및 불 필요한 코드 정리

### DIFF
--- a/app/dashboard/_components/DashboardContent.tsx
+++ b/app/dashboard/_components/DashboardContent.tsx
@@ -1,0 +1,15 @@
+import ProfileSection from "./profileSection"
+import TokenSection from "./tokenSection/TokenSection"
+
+type Tab = "profile" | "token" | string
+
+export default function DashboardContent({ currentTab }: { currentTab: Tab }) {
+  switch (currentTab) {
+    case "profile":
+      return <ProfileSection />
+    case "token":
+      return <TokenSection />
+    default:
+      return <ProfileSection />
+  }
+}

--- a/app/dashboard/_components/DashboardPageContainer.tsx
+++ b/app/dashboard/_components/DashboardPageContainer.tsx
@@ -1,0 +1,22 @@
+export default function DashboardPageContainer({
+    children,
+  }: {
+    children: React.ReactNode
+  }) {
+    return (
+      <div className="flex min-h-screen bg-base-200">
+        <div className="flex-1 p-4">
+          {/* 헤더 */}
+          <div className="flex justify-between items-center h-12 mb-7 px-2">
+            <h1 className="text-2xl md:text-3xl font-bold">마이 페이지</h1>
+          </div>
+  
+          {/* 탭 + 콘텐츠 */}
+          <div className="flex flex-col gap-6">
+            {children}
+          </div>
+        </div>
+      </div>
+    )
+  }
+  

--- a/app/dashboard/chat/_components/RightSection.tsx
+++ b/app/dashboard/chat/_components/RightSection.tsx
@@ -1,4 +1,3 @@
-"use client";
 
 export default function RightSection({
   children,

--- a/app/dashboard/chat/page.tsx
+++ b/app/dashboard/chat/page.tsx
@@ -4,6 +4,9 @@ import RightSection from './_components/RightSection'
 import ChatRoom from './_components/ChatRoom'
 import SearchChatInput from './_components/SearchChatInput'
 import ChatList from './_components/ChatList'
+
+
+export const dynamic = 'force-dynamic'
 export const metadata = {
   title: '채팅 - Game Mate',
   description: '게임 메이트와 채팅으로 소통하세요',

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,48 +1,28 @@
 import { Suspense } from "react";
 
-import ProfileSection from "./_components/profileSection";
-import TokenSection from "./_components/tokenSection/TokenSection";
+import DashboardPageContainer from "./_components/DashboardPageContainer"
 import ClientTabNav from "./_components/ClientTabNav";
-// searchParams는 서버 컴포넌트의 props로 자동으로 전달됩니다
+import DashboardContent from "./_components/DashboardContent"
+
 export default async function DashboardPage({
   searchParams,
 }: {
-  searchParams: Promise<{ tab?: string }>;
+  searchParams: Promise<{ tab?: string }>
 }) {
-  const resolvedSearchParams = await searchParams;
-  const currentTab = resolvedSearchParams.tab || "profile";
-
-  const renderSection = () => {
-    switch (currentTab) {
-      case "profile":
-        return <ProfileSection />;
-      case "token":
-        return <TokenSection />;
-      default:
-        return <ProfileSection />;
-    }
-  };
+  const { tab } = await searchParams
+  const currentTab = tab ?? "profile"
 
   return (
-    <div className="flex min-h-screen bg-base-200">
-      <div className="flex-1 p-4">
-        {/* 헤더 섹션 */}
-        <div className="flex justify-between items-center h-12 mb-7 px-2">
-          <h1 className="text-2xl md:text-3xl font-bold">마이 페이지</h1>
-        </div>
+    <DashboardPageContainer>
 
-        <div className="flex flex-col gap-6">
-          {/* 클라이언트 컴포넌트로 분리된 TabNav */}
-          <ClientTabNav currentTab={currentTab} />
-          
-          {/* 탭에 따른 컴포넌트 렌더링 */}
-          <Suspense fallback={<div>로딩 중...</div>}>
-            {renderSection()}
-          </Suspense>
-        </div>
-      </div>
-    </div>
-  );
+      <ClientTabNav currentTab={currentTab} />
+      {/* 서버 경계에서 스트리밍 */}
+      <Suspense >
+        <DashboardContent currentTab={currentTab} />
+      </Suspense>
+
+    </DashboardPageContainer>
+  )
 }
 
 


### PR DESCRIPTION

Why: 페이지 가독성과 유지보수성 향상, 서버 스트리밍/서스펜스 이점 보존

What:
- 레이아웃/셸 전담 컨테이너 도입
- 탭에 따른 섹션 스위칭용 콘텐츠 컴포넌트 도입
- 페이지는 searchParams 해석 → currentTab 결정 → 네비 + Suspense(콘텐츠)만 조립
- 섹션 내부 스켈레톤/에러 처리 우선, 상단 fallback 최소화
- 서버 컴포넌트 경계 유지로 스트리밍 특성 보존

How:
- searchParams를 await하여 currentTab 기본값 'profile'로 결정
- Suspense 경계를 서버 트리에 배치(필요 시 key=currentTab로 경계 초기화)
- 클라이언트 컴포넌트는 탭 네비만 유지

Test Plan:
- ?tab=profile/token 전환 시 헤더/탭 유지되고 섹션만 갱신되는지 확인
- 로딩 시 셸 먼저, 섹션 데이터 합류 흐름 확인
- 빌드/린트 통과
