### PR TITLE
[refactor] : 카테고리 페이지 선언적 조합(데이터 컨테이너 + 컨텍스트 분리)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ next-env.d.ts
 /dailyRecord/
 supabase/schema.sql
 supabase/.temp/
+
+#eslintcache
+.eslintcache
+**/.eslintcache

--- a/app/category/[categoryId]/page.tsx
+++ b/app/category/[categoryId]/page.tsx
@@ -1,112 +1,14 @@
-'use client' // Hooks 사용을 위해 클라이언트 컴포넌트로 선언
+import CategoryIdPageContainer from "../_components/CategoryIdPageContainer"
+import CategoryHeader from "../_components/CategoryHeader"
+import CategoryMatesSection from "../_components/CategoryMatesSection"
 
-import { useParams } from 'next/navigation' // next/navigation 사용
-import { useInView } from 'react-intersection-observer'
-import { Fragment } from 'react' // useEffect 제거
-
-import { useMatesByCategoryInfiniteQuery } from '@/hooks/api/category/useCategoryQueries'
-
-import type { MateCardData } from '../_types/categoryPage.types'
-import LoadingSpinner from '../../../components/ui/LoadingSpinner' // 로딩 스피너 임포트
-import { MateCard } from '../_components/MateCard' // MateCard 임포트 경로 확인
-import CategoryHeader from '../_components/CategoryHeader'
-
-export default function CategoryIdPage() {
-  const params = useParams()
-  // params.categoryId가 string | string[] 일 수 있으므로 string으로 처리
-  const rawCategoryId = params.categoryId
-  const categoryId = Array.isArray(rawCategoryId) ? rawCategoryId[0] : rawCategoryId
-
-  // 유효성 검증 (Hook 호출 전에 수행)
-  const isValidCategoryId = typeof categoryId === 'string' && categoryId.length > 0
-
-  // Hook들은 항상 최상위에서 호출 (조건부 호출 금지)
-  const {
-    data,
-    error,
-    fetchNextPage,
-    hasNextPage,
-    isLoading,
-    isFetchingNextPage,
-  } = useMatesByCategoryInfiniteQuery(isValidCategoryId ? categoryId : undefined)
-
-  const { ref } = useInView({
-    threshold: 0, // 요소가 1px이라도 보이면 트리거
-    onChange: (inView) => {
-      if (inView && hasNextPage && !isFetchingNextPage) {
-        fetchNextPage()
-      }
-    },
-  })
-
-  // 유효하지 않은 경우 조기 반환 (Hook 호출 후에 수행)
-  if (!isValidCategoryId) {
-    return (
-      <div className="text-center py-10 text-red-500">
-        잘못된 카테고리입니다.
-      </div>
-    )
-  }
-
-  // 로딩 상태 처리
-  if (isLoading) {
-    return (
-      <div className="flex justify-center items-center min-h-[calc(100vh-200px)]">
-        <LoadingSpinner size="lg" />
-      </div>
-    )
-  }
-
-  // 에러 상태 처리
-  if (error) {
-    return (
-      <div className="text-center py-10 text-red-500">
-        데이터를 불러오는 중 오류가 발생했습니다: {error.message}
-      </div>
-    )
-  }
-
-  // 데이터가 없을 경우 (초기 로딩 후)
-  const allMates = data?.pages.flatMap(page => page.mates) ?? []
-  const noMatesFound = !isLoading && allMates.length === 0
+export default async function Page({ params }: { params: Promise<{ categoryId: string }> }) {
+  const { categoryId } = await params
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <CategoryHeader/>
-
-      {noMatesFound ? (
-        <p className="text-center text-gray-500 py-10">
-          아직 등록된 메이트가 없습니다.
-        </p>
-      ) : (
-        <>
-          {/* 메이트 목록 - 5열 그리드 */}
-          <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4">
-            {data?.pages.map((page, i) => (
-              <Fragment key={i}>
-                {page.mates?.map((mate: MateCardData) => (
-                  <MateCard key={mate.id} mate={mate} />
-                ))}
-              </Fragment>
-            ))}
-          </div>
-
-          {/* 무한 스크롤 트리거 및 로딩 표시 */}
-          <div ref={ref} className="h-20 flex justify-center items-center mt-8">
-            {isFetchingNextPage ? (
-              <LoadingSpinner />
-            ) : hasNextPage ? (
-              // 더 로드할 메이트가 있을 때만 "스크롤하여 더 보기" 표시
-              <span className="text-gray-500">스크롤하여 더 보기...</span>
-            ) : (
-              // 더 로드할 페이지가 없고, 데이터가 있을 때 완료 메시지 표시
-              allMates.length > 0 && <p className="text-sm text-gray-500">모든 메이트를 불러왔습니다.</p>
-            )}
-          </div>
-        </>
-      )}
-    </div>
+    <CategoryIdPageContainer>
+      <CategoryHeader categoryId={categoryId} />
+      <CategoryMatesSection categoryId={categoryId} />
+    </CategoryIdPageContainer>
   )
 }
-
-

--- a/app/category/_components/CategoryHeader.tsx
+++ b/app/category/_components/CategoryHeader.tsx
@@ -1,31 +1,20 @@
-import Image from "next/image";
-import { useParams } from "next/navigation";
+"use client"
 
-import { useGameHeaderQuery } from "@/hooks/api/category/useCategoryQueries";
+import Image from "next/image"
 
-export default function CategoryHeader() {
-  const params = useParams();
-  const categoryId = params.categoryId as string;
-  const {
-    data: gameHeader,
-    isLoading,
-    error,
-  } = useGameHeaderQuery(categoryId);
+import { useGameHeaderQuery } from "@/hooks/api/category/useCategoryQueries"
 
-  if (isLoading) {
-    return <CategoryHeaderSkeleton />;
-  }
+export default function CategoryHeader({ categoryId }: { categoryId: string }) {
+  const { data: gameHeader, isLoading, error } = useGameHeaderQuery(categoryId)
 
-  if (error) {
-    // TODO: Implement a more user-friendly error display
-    return <div>Error loading category header.</div>;
-  }
-
-  if (!gameHeader) {
-    // This case might happen if the API returns null or an empty object successfully
-    // Or if the data is somehow invalid after loading
-    return <div>Category data not found.</div>; // Or render nothing, or a specific message
-  }
+  if (isLoading) return <CategoryHeaderSkeleton />
+  if (error)
+    return (
+      <div role="alert" className="text-red-500">
+        카테고리 정보를 불러오지 못했습니다.
+      </div>
+    )
+  if (!gameHeader) return <div className="text-gray-500">카테고리 정보를 찾을 수 없습니다.</div>
 
   return (
     <div className="flex items-start p-4 border-b border-gray-100">
@@ -41,28 +30,31 @@ export default function CategoryHeader() {
       <div className="m-4">
         <p className="text-4xl font-bold">{gameHeader.description}</p>
         <ul className="flex gap-2 py-2">
-          {gameHeader.genre.map((genre) => (
-            <li key={genre} className="text-xs text-gray-500 border border-gray-200 rounded-md px-1">
+          {gameHeader.genre.map((genre: string) => (
+            <li
+              key={genre}
+              className="text-xs text-gray-600 border border-gray-200 rounded-md px-1"
+            >
               {genre}
             </li>
           ))}
         </ul>
       </div>
     </div>
-  );
+  )
 }
 
 function CategoryHeaderSkeleton() {
   return (
-    <div className="flex animate-pulse items-center p-4 border-b border-gray-950">
-      <div className="w-[135px] h-[180px] bg-gray-300 rounded" />
+    <div className="flex items-center p-4 border-b border-gray-100">
+      <div className="w-[135px] h-[180px] bg-gray-200 rounded animate-pulse" />
       <div className="ml-4 flex-1 space-y-4 py-1">
-        <div className="h-6 bg-gray-300 rounded w-3/4" />
+        <div className="h-6 bg-gray-200 rounded w-3/4 animate-pulse" />
         <div className="flex gap-2">
-          <div className="h-6 bg-gray-300 rounded w-16" />
-          <div className="h-6 bg-gray-300 rounded w-16" />
+          <div className="h-6 bg-gray-200 rounded w-16 animate-pulse" />
+          <div className="h-6 bg-gray-200 rounded w-16 animate-pulse" />
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/app/category/_components/CategoryIdPageContainer.tsx
+++ b/app/category/_components/CategoryIdPageContainer.tsx
@@ -1,0 +1,3 @@
+export default function CategoryIdPageContainer({ children }: { children: React.ReactNode }) {
+  return <div className="container mx-auto px-4 py-8">{children}</div>
+}

--- a/app/category/_components/CategoryMatesSection.tsx
+++ b/app/category/_components/CategoryMatesSection.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { useMemo } from "react"
+import { useInView } from "react-intersection-observer"
+
+import { useMatesByCategoryInfiniteQuery } from "@/hooks/api/category/useCategoryQueries"
+import LoadingSpinner from "@/components/ui/LoadingSpinner"
+
+import type { MateCardData } from "../_types/categoryPage.types"
+import { MatesProvider } from "../_context/MatesContexts"
+
+import MatesGrid from "./MatesGrid"
+import InfiniteFooter from "./InfiniteFooter"
+
+export default function CategoryMatesSection({ categoryId }: { categoryId: string }) {
+  const { data, error, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage } =
+    useMatesByCategoryInfiniteQuery(categoryId)
+
+  const mates: ReadonlyArray<MateCardData> = useMemo(
+    () => (data?.pages ?? []).flatMap((p) => p.mates),
+    [data],
+  )
+
+  const noMates = !isLoading && mates.length === 0
+
+  const matesValue = useMemo(() => ({ mates }), [mates])
+  const paginationValue = useMemo(
+    () => ({
+      total: mates.length,
+      hasNextPage: !!hasNextPage,
+      isFetchingNextPage,
+    }),
+    [mates.length, hasNextPage, isFetchingNextPage],
+  )
+
+  const { ref } = useInView({
+    rootMargin: "400px 0px",
+    threshold: 0,
+    onChange: (inView) => {
+      if (inView && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage()
+      }
+    },
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center min-h-[40vh]">
+        <LoadingSpinner size="lg" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div role="alert" className="text-center py-10 text-red-500">
+        메이트 목록을 불러오는 중 오류가 발생했습니다.
+      </div>
+    )
+  }
+
+  if (noMates) {
+    return <p className="text-center text-gray-500 py-10">아직 등록된 메이트가 없습니다.</p>
+  }
+
+  return (
+    <MatesProvider value={matesValue} pagination={paginationValue}>
+      <MatesGrid />
+      <InfiniteFooter observeRef={ref} />
+    </MatesProvider>
+  )
+}

--- a/app/category/_components/InfiniteFooter.tsx
+++ b/app/category/_components/InfiniteFooter.tsx
@@ -1,0 +1,26 @@
+"use client"
+import type { RefCallback } from "react"
+
+import LoadingSpinner from "@/components/ui/LoadingSpinner"
+
+import { usePagination } from "../_context/MatesContexts"
+
+export default function InfiniteFooter({
+  observeRef,
+}: {
+  observeRef: RefCallback<HTMLDivElement>
+}) {
+  const { isFetchingNextPage, hasNextPage, total } = usePagination()
+
+  return (
+    <div ref={observeRef} className="h-20 flex justify-center items-center mt-8">
+      {isFetchingNextPage ? (
+        <LoadingSpinner />
+      ) : hasNextPage ? (
+        <span className="text-gray-500">스크롤하여 더 보기...</span>
+      ) : total > 0 ? (
+        <p className="text-sm text-gray-500">모든 메이트를 불러왔습니다.</p>
+      ) : null}
+    </div>
+  )
+}

--- a/app/category/_components/MatesGrid.tsx
+++ b/app/category/_components/MatesGrid.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { memo } from "react"
+
+import { useMates } from "../_context/MatesContexts"
+
+import { MateCard } from "./MateCard"
+
+function MatesGridInner() {
+  const { mates } = useMates()
+
+  return (
+    <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+      {mates.map((mate) => (
+        <MateCard key={mate.id} mate={mate} />
+      ))}
+    </div>
+  )
+}
+
+const MatesGrid = memo(MatesGridInner)
+export default MatesGrid

--- a/app/category/_context/MatesContexts.tsx
+++ b/app/category/_context/MatesContexts.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { createContext, useContext } from "react"
+
+import type { MateCardData } from "../_types/categoryPage.types"
+
+type MatesValue = Readonly<{ mates: ReadonlyArray<MateCardData> }>
+type PaginationValue = {
+  total: number
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+}
+
+const MatesCtx = createContext<MatesValue | null>(null)
+const PaginationCtx = createContext<PaginationValue | null>(null)
+
+export function MatesProvider({
+  value,
+  pagination,
+  children,
+}: {
+  value: MatesValue
+  pagination: PaginationValue
+  children: React.ReactNode
+}) {
+  return (
+    <MatesCtx.Provider value={value}>
+      <PaginationCtx.Provider value={pagination}>{children}</PaginationCtx.Provider>
+    </MatesCtx.Provider>
+  )
+}
+
+export function useMates() {
+  const v = useContext(MatesCtx)
+  if (!v) throw new Error("useMates must be used within MatesProvider")
+  return v
+}
+
+export function usePagination() {
+  const v = useContext(PaginationCtx)
+  if (!v) throw new Error("usePagination must be used within MatesProvider")
+  return v
+}

--- a/stores/chatStore.ts
+++ b/stores/chatStore.ts
@@ -1,17 +1,17 @@
-'use client'
+"use client"
 
-import { create } from 'zustand'
-import { createClient } from '@/supabase/functions/client'
+import { create } from "zustand"
 
-import { Database } from '@/types/database.types'
+import { createClient } from "@/supabase/functions/client"
+import { type Database } from "@/types/database.types"
 
 // 클라이언트 컴포넌트용 Supabase 인스턴스 생성
 const supabase = createClient()
 
-type Tables = Database['public']['Tables']
-type ChatRoomRow = Tables['chat_rooms']['Row']
-type ChatRoomParticipantRow = Tables['chat_room_participants']['Row']
-type MessageRow = Tables['messages']['Row']
+type Tables = Database["public"]["Tables"]
+type ChatRoomRow = Tables["chat_rooms"]["Row"]
+type ChatRoomParticipantRow = Tables["chat_room_participants"]["Row"]
+type MessageRow = Tables["messages"]["Row"]
 
 interface ExtendedChatRoom extends ChatRoomRow {
   chat_room_participants: ChatRoomParticipantRow[]
@@ -52,7 +52,7 @@ interface ChatState {
   messages: Message[]
   isLoading: boolean
   error: string | null
-  
+
   fetchChatRooms: () => Promise<void>
   fetchMessages: (roomId: string) => Promise<void>
   sendMessage: (content: string, receiverId: string, chatRoomId?: string | null) => Promise<void>
@@ -70,88 +70,93 @@ export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
   isLoading: false,
   error: null,
-  
+
   setSelectedChat: (chat) => set({ selectedChat: chat }),
-  
+
   fetchChatRooms: async () => {
     try {
       set({ isLoading: true, error: null })
       const { data: userData, error: userError } = await supabase.auth.getUser()
       if (userError) throw userError
-      if (!userData.user) throw new Error('사용자 정보를 찾을 수 없습니다')
+      if (!userData.user) throw new Error("사용자 정보를 찾을 수 없습니다")
       const userId = userData.user.id
       const { data: roomsData, error: roomsError } = await supabase
-        .from('chat_rooms')
-        .select(`
+        .from("chat_rooms")
+        .select(
+          `
           id,
           last_message,
           last_message_time,
           chat_room_participants!left(id, chat_room_id, user_id, unread_count)
-        `)
-        .order('last_message_time', { ascending: false })
+        `,
+        )
+        .order("last_message_time", { ascending: false })
       if (roomsError) throw roomsError
       const typedRoomsData = roomsData as unknown as ExtendedChatRoom[]
       const chatRooms = await Promise.all(
         typedRoomsData.map(async (room) => {
-          const participant = room.chat_room_participants?.find(p => p.user_id !== userId)
+          const participant = room.chat_room_participants?.find((p) => p.user_id !== userId)
           const otherParticipantId = participant?.user_id
-          if (!otherParticipantId) return { 
-            ...room, 
-            participants: room.chat_room_participants || [],
-            otherUser: null 
-          }
+          if (!otherParticipantId)
+            return {
+              ...room,
+              participants: room.chat_room_participants || [],
+              otherUser: null,
+            }
           const { data: otherUserData } = await supabase
-            .from('users')
-            .select('id, name, profile_circle_img, is_online')
-            .eq('id', otherParticipantId)
+            .from("users")
+            .select("id, name, profile_circle_img, is_online")
+            .eq("id", otherParticipantId)
             .single()
           return {
             ...room,
             participants: room.chat_room_participants || [],
-            otherUser: otherUserData
+            otherUser: otherUserData,
           }
-        })
+        }),
       )
       set({ chatRooms, isLoading: false })
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '채팅방 목록을 가져오는 중 오류가 발생했습니다'
+      const errorMessage =
+        error instanceof Error ? error.message : "채팅방 목록을 가져오는 중 오류가 발생했습니다"
       set({ error: errorMessage, isLoading: false })
     }
   },
-  
+
   fetchMessages: async (roomId) => {
     try {
       set({ isLoading: true, error: null })
       const { data: messagesData, error: messagesError } = await supabase
-        .from('messages')
-        .select('*')
-        .eq('chat_room_id', roomId)
-        .order('created_at', { ascending: true })
+        .from("messages")
+        .select("*")
+        .eq("chat_room_id", roomId)
+        .order("created_at", { ascending: true })
       if (messagesError) throw messagesError
       set({ messages: messagesData || [], currentChatRoom: roomId, isLoading: false })
       await get().markAsRead(roomId)
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '메시지를 가져오는 중 오류가 발생했습니다'
+      const errorMessage =
+        error instanceof Error ? error.message : "메시지를 가져오는 중 오류가 발생했습니다"
       set({ error: errorMessage, isLoading: false })
     }
   },
-  
+
   sendMessage: async (content, receiverId, chatRoomId = null) => {
     try {
       set({ isLoading: true, error: null })
       const { data: userData, error: userError } = await supabase.auth.getUser()
       if (userError) throw userError
-      if (!userData.user) throw new Error('사용자 정보를 찾을 수 없습니다')
+      if (!userData.user) throw new Error("사용자 정보를 찾을 수 없습니다")
       const senderId = userData.user.id
       const insertData = {
         content,
         sender_id: senderId,
         receiver_id: receiverId,
         is_read: false,
-        ...(chatRoomId && { chat_room_id: chatRoomId })
+        ...(chatRoomId && { chat_room_id: chatRoomId }),
       } as const
       const { data: messageData, error: messageError } = await supabase
-        .from('messages')
+        .from("messages")
         .insert(insertData)
         .select()
       if (messageError) throw messageError
@@ -164,62 +169,65 @@ export const useChatStore = create<ChatState>((set, get) => ({
       await get().fetchChatRooms()
       set({ isLoading: false })
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '메시지 전송 중 오류가 발생했습니다'
+      const errorMessage =
+        error instanceof Error ? error.message : "메시지 전송 중 오류가 발생했습니다"
       set({ error: errorMessage, isLoading: false })
     }
   },
-  
+
   markAsRead: async (roomId) => {
     try {
       const { data: userData, error: userError } = await supabase.auth.getUser()
       if (userError) throw userError
-      if (!userData.user) throw new Error('사용자 정보를 찾을 수 없습니다')
+      if (!userData.user) throw new Error("사용자 정보를 찾을 수 없습니다")
       const userId = userData.user.id
-      const { error: rpcError } = await supabase.rpc('mark_messages_as_read', {
+      const { error: rpcError } = await supabase.rpc("mark_messages_as_read", {
         p_chat_room_id: roomId,
-        p_user_id: userId
+        p_user_id: userId,
       })
       if (rpcError) throw rpcError
       await get().fetchChatRooms()
     } catch (error) {
-      console.error('Error marking messages as read:', error)
+      console.error("Error marking messages as read:", error)
     }
   },
-  
+
   setCurrentChatRoom: (roomId) => {
     set({ currentChatRoom: roomId })
     if (roomId) {
       get().fetchMessages(roomId)
     }
   },
-  
+
   findOrCreateChatWithUser: async (userId: string) => {
     try {
       set({ isLoading: true, error: null })
       const { data: userData, error: userError } = await supabase.auth.getUser()
       if (userError) {
-        console.error('인증 오류:', userError)
-        throw new Error('로그인 세션을 확인하세요: ' + userError.message)
+        console.error("인증 오류:", userError)
+        throw new Error("로그인 세션을 확인하세요: " + userError.message)
       }
-      if (!userData.user) throw new Error('사용자 정보를 찾을 수 없습니다')
+      if (!userData.user) throw new Error("사용자 정보를 찾을 수 없습니다")
       const currentUserId = userData.user.id
       const { data: existingRooms } = await supabase
-        .from('chat_room_participants')
-        .select(`
+        .from("chat_room_participants")
+        .select(
+          `
           chat_room_id,
           chat_rooms!left(id)
-        `)
-        .eq('user_id', currentUserId)
+        `,
+        )
+        .eq("user_id", currentUserId)
       if (existingRooms && existingRooms.length > 0) {
         const chatRoomIds = existingRooms
-          .filter(room => room.chat_room_id)
-          .map(room => room.chat_room_id as string)
+          .filter((room) => room.chat_room_id)
+          .map((room) => room.chat_room_id as string)
         if (chatRoomIds.length > 0) {
           const { data: otherUserRooms } = await supabase
-            .from('chat_room_participants')
-            .select('chat_room_id')
-            .eq('user_id', userId)
-            .in('chat_room_id', chatRoomIds)
+            .from("chat_room_participants")
+            .select("chat_room_id")
+            .eq("user_id", userId)
+            .in("chat_room_id", chatRoomIds)
           if (otherUserRooms && otherUserRooms.length > 0) {
             const roomId = otherUserRooms[0].chat_room_id as string
             get().setCurrentChatRoom(roomId)
@@ -229,29 +237,27 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
       }
       const { data, error } = await supabase
-        .from('chat_rooms')
+        .from("chat_rooms")
         .insert({
-          last_message: '대화가 시작되었습니다.',
-          last_message_time: new Date().toISOString()
+          last_message: "대화가 시작되었습니다.",
+          last_message_time: new Date().toISOString(),
         })
         .select()
         .single()
       if (error) throw error
-      const { error: participantsError } = await supabase
-        .from('chat_room_participants')
-        .insert([
-          { chat_room_id: data.id, user_id: currentUserId, unread_count: 0 },
-          { chat_room_id: data.id, user_id: userId, unread_count: 0 }
-        ])
+      const { error: participantsError } = await supabase.from("chat_room_participants").insert([
+        { chat_room_id: data.id, user_id: currentUserId, unread_count: 0 },
+        { chat_room_id: data.id, user_id: userId, unread_count: 0 },
+      ])
       if (participantsError) throw participantsError
       const { error: messageError } = await supabase
-        .from('messages')
+        .from("messages")
         .insert({
-          content: '대화가 시작되었습니다.',
+          content: "대화가 시작되었습니다.",
           sender_id: currentUserId,
           receiver_id: userId,
           chat_room_id: data.id,
-          is_read: false
+          is_read: false,
         })
         .select()
       if (messageError) throw messageError
@@ -260,36 +266,41 @@ export const useChatStore = create<ChatState>((set, get) => ({
       set({ isLoading: false })
       return data.id
     } catch (error) {
-      console.error('채팅방 생성 오류:', error)
-      const errorMessage = error instanceof Error ? error.message : '채팅방을 생성하는 중 오류가 발생했습니다'
+      console.error("채팅방 생성 오류:", error)
+      const errorMessage =
+        error instanceof Error ? error.message : "채팅방을 생성하는 중 오류가 발생했습니다"
       set({ error: errorMessage, isLoading: false })
       return null
     }
   },
-  
+
   subscribeToMessages: () => {
     const subscription = supabase
-      .channel('public:messages')
-      .on('postgres_changes', { 
-        event: 'INSERT', 
-        schema: 'public', 
-        table: 'messages' 
-      }, async (payload) => {
-        const { data: userData } = await supabase.auth.getUser()
-        const userId = userData.user?.id
-        const currentRoom = get().currentChatRoom
-        if (currentRoom && currentRoom === payload.new.chat_room_id) {
-          get().fetchMessages(currentRoom)
-          if (payload.new.receiver_id === userId) {
-            get().markAsRead(currentRoom)
+      .channel("public:messages")
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+        },
+        async (payload) => {
+          const { data: userData } = await supabase.auth.getUser()
+          const userId = userData.user?.id
+          const currentRoom = get().currentChatRoom
+          if (currentRoom && currentRoom === payload.new.chat_room_id) {
+            get().fetchMessages(currentRoom)
+            if (payload.new.receiver_id === userId) {
+              get().markAsRead(currentRoom)
+            }
+          } else {
+            get().fetchChatRooms()
           }
-        } else {
-          get().fetchChatRooms()
-        }
-      })
+        },
+      )
       .subscribe()
     return () => {
       supabase.removeChannel(subscription)
     }
-  }
+  },
 }))

--- a/types/database.table.types.ts
+++ b/types/database.table.types.ts
@@ -1,22 +1,16 @@
-import { Database } from "./database.types";
+import { type Tables } from "./database.types"
 
-export type Tables = Database['public']['Tables']
-export type Album_imagesRow = Tables['album_images']['Row']
-export type UsersRow = Tables['users']['Row']
-export type ProfilesRow = Tables['profiles']['Row']
-export type Chat_room_participantsRow = Tables['chat_room_participants']['Row']
-export type Chat_roomsRow = Tables['chat_rooms']['Row']
-export type MessagesRow = Tables['messages']['Row']
-export type PaymentsRow = Tables['payments']['Row']
-export type Token_transactionsRow = Tables['token_transactions']['Row']
-export type User_tokensRow = Tables['user_tokens']['Row']
-export type RequestsRow = Tables['requests']['Row']
-export type ReviewsRow = Tables['reviews']['Row']
-export type GamesRow = Tables['games']['Row']
-
-
-
-
-
-
-
+// 레거시 Row 별칭을 제네릭 기반으로 유지하여 호환성 보장
+// 추가 헬퍼 제네릭 -> TablesInsert, TablesUpdate, Enums
+export type Album_imagesRow = Tables<"album_images">
+export type UsersRow = Tables<"users">
+export type ProfilesRow = Tables<"profiles">
+export type Chat_room_participantsRow = Tables<"chat_room_participants">
+export type Chat_roomsRow = Tables<"chat_rooms">
+export type MessagesRow = Tables<"messages">
+export type PaymentsRow = Tables<"payments">
+export type Token_transactionsRow = Tables<"token_transactions">
+export type User_tokensRow = Tables<"user_tokens">
+export type RequestsRow = Tables<"requests">
+export type ReviewsRow = Tables<"reviews">
+export type GamesRow = Tables<"games">


### PR DESCRIPTION

Why
- 페이지 가독성/관심사 분리
- 무한 스크롤 토글 시 리스트 불필요 리렌더 제거

What
- Server page는 params 해석/조립 전용
- CategoryMatesSection에서 무한 스크롤/쿼리 집중
- Mates/Pagination 컨텍스트 분리, 값 아이덴티티 안정화
- MatesGrid/InfiniteFooter 프레젠테이션 분리

Test Plan
- 무한 스크롤 1사이클 렌더 횟수/시간 비교
- 로딩/에러/빈 상태 UX 확인