### PR TITLE
[refactor] : Supabase 클라이언트 싱글턴화 & Task 구독 훅 안정화

### DIFF
--- a/app/dashboard/task/_hooks/useTaskSubscription.ts
+++ b/app/dashboard/task/_hooks/useTaskSubscription.ts
@@ -1,83 +1,74 @@
-'use client'
+// useTaskSubscription.ts
+"use client"
 
-import { useEffect } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import { createClient } from '@/supabase/functions/client';
-import type { RealtimeChannel } from '@supabase/supabase-js';
+import { useEffect, useRef } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import type { RealtimeChannel, RealtimePostgresChangesPayload } from "@supabase/supabase-js"
 
-import { useAuthStore } from '@/stores/authStore'; // Auth 스토어 임포트
+import { createClient } from "@/supabase/functions/client"
+import type { Database } from "@/types/database.types"
+import { useAuthStore } from "@/stores/authStore"
 
-// 타입 정의: 훅의 인자 (콜백 대신 내부에서 invalidate 사용)
-// interface UseTaskSubscriptionOptions {
-//   userId: string | undefined; // 사용자 ID (undefined 가능성 처리)
-// }
+// (선택) 모듈 스코프 싱글턴 참조로 만들어두면 deps 경고도 자연 해소됩니다.
+const supabase = createClient()
 
-export function useTaskSubscription(): void { // 인자 제거
-  const queryClient = useQueryClient();
-  const supabase = createClient();
-  const user = useAuthStore((state) => state.user); // 스토어에서 사용자 정보 가져오기
-  const userId = user?.id; // 사용자 ID 추출
+type RequestRow = Database["public"]["Tables"]["requests"]["Row"]
+
+export function useTaskSubscription(): void {
+  const queryClient = useQueryClient()
+  const userId = useAuthStore((s) => s.user?.id)
+  const isCleaningUpRef = useRef(false)
 
   useEffect(() => {
-    // 사용자 ID가 없으면 구독 설정 안 함
     if (!userId) {
-      console.log('[useTaskSubscription] User ID not available, skipping subscription.');
-      return;
+      console.log("[useTaskSubscription] User ID not available, skipping subscription.")
+      return
     }
 
-    console.log(`[useTaskSubscription] Setting up subscription for user: ${userId}`);
-
-    // 데이터베이스 변경 시 실행될 콜백 함수
-    const handleDbChange = (payload: any) => {
-      console.log('[useTaskSubscription] DB Change detected!', payload);
-      // 관련 쿼리를 무효화하여 데이터 리프레시 트리거
-      queryClient.invalidateQueries({ queryKey: ['receivedOrders'] });
-      queryClient.invalidateQueries({ queryKey: ['requestedOrders'] });
-      console.log('[useTaskSubscription] Invalidated queries: receivedOrders, requestedOrders');
+    const handleDbChange = (payload: RealtimePostgresChangesPayload<RequestRow>) => {
+      console.log("[useTaskSubscription] DB Change detected!", {
+        eventType: payload.eventType,
+        new: payload.new,
+        old: payload.old,
+      })
+      queryClient.invalidateQueries({ queryKey: ["receivedOrders"] })
+      queryClient.invalidateQueries({ queryKey: ["requestedOrders"] })
     }
 
-    // requests 테이블 변경 감지를 위한 채널 설정
     const channel: RealtimeChannel = supabase
-      .channel(`realtime-requests-tasklist-${userId}`) // 사용자별 고유 채널 이름 권장
+      .channel(`realtime-requests-tasklist-${userId}`)
       .on(
-        'postgres_changes',
-        {
-          event: '*', // 모든 이벤트 (INSERT, UPDATE, DELETE) 감지
-          schema: 'public',
-          table: 'requests',
-          filter: `provider_id=eq.${userId}` // 현재 사용자가 제공자인 경우
-        },
-        handleDbChange
+        "postgres_changes",
+        { event: "*", schema: "public", table: "requests", filter: `provider_id=eq.${userId}` },
+        handleDbChange,
       )
       .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'requests',
-          filter: `requester_id=eq.${userId}` // 현재 사용자가 요청자인 경우
-        },
-        handleDbChange
+        "postgres_changes",
+        { event: "*", schema: "public", table: "requests", filter: `requester_id=eq.${userId}` },
+        handleDbChange,
       )
       .subscribe((status, err) => {
-        if (status === 'SUBSCRIBED') {
-          console.log(`[useTaskSubscription] Subscribed successfully for user ${userId}!`);
-        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
-          console.error(`[useTaskSubscription] Subscription failed or closed for user ${userId}:`, status, err);
+        if (status === "SUBSCRIBED") {
+          console.log(`[useTaskSubscription] Subscribed successfully for user ${userId}!`)
+        } else if (status === "CLOSED") {
+          const level: "log" | "error" = isCleaningUpRef.current ? "log" : "error"
+          console[level](`[useTaskSubscription] Channel closed for user ${userId}:`, status, err)
+        } else if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
+          console.error(`[useTaskSubscription] Subscription issue for user ${userId}:`, status, err)
         }
-      });
+      })
 
-    // 컴포넌트 언마운트 시 또는 의존성 변경 시 구독 해제
     return () => {
-      console.log(`[useTaskSubscription] Cleaning up subscription for user: ${userId}`);
-      if (channel) {
-        supabase.removeChannel(channel)
-          .then(() => console.log(`[useTaskSubscription] Channel removed successfully for user ${userId}.`))
-          .catch(err => console.error(`[useTaskSubscription] Error removing channel for user ${userId}:`, err));
-      }
+      isCleaningUpRef.current = true
+      supabase
+        .removeChannel(channel)
+        .then(() =>
+          console.log(`[useTaskSubscription] Channel removed successfully for user ${userId}.`),
+        )
+        .catch((err) =>
+          console.error(`[useTaskSubscription] Error removing channel for user ${userId}:`, err),
+        )
     }
-  // 이제 userId를 내부에서 가져오므로, userId가 변경될 때 useEffect가 다시 실행되도록 의존성 배열에 추가
-  }, [userId, queryClient, supabase]);
-
-  // 이 훅은 값을 반환하지 않음 (side effect만 처리)
+    // supabase는 모듈 스코프(정적)이므로 deps에 넣을 필요 없음
+  }, [userId, queryClient])
 }

--- a/app/dashboard/task/page.tsx
+++ b/app/dashboard/task/page.tsx
@@ -1,10 +1,12 @@
-import { Suspense } from "react";
+import { Suspense } from "react"
 
-import TaskList from "./_components/TaskList";
-import TaskPageContainer from "./_components/TaskPageContainer";
-import TaskPageNavTab from "./_components/TaskPageNavTab";
-import TaskPageNavTabSkeleton from "./_components/skeletons/TaskPageNavTabSkeleton";
-import TaskListSkeleton from "./_components/skeletons/TaskListSkeleton";
+import TaskList from "./_components/TaskList"
+import TaskPageContainer from "./_components/TaskPageContainer"
+import TaskPageNavTab from "./_components/TaskPageNavTab"
+import TaskPageNavTabSkeleton from "./_components/skeletons/TaskPageNavTabSkeleton"
+import TaskListSkeleton from "./_components/skeletons/TaskListSkeleton"
+
+export const dynamic = "force-dynamic"
 
 export default function TaskPage() {
   return (
@@ -17,5 +19,5 @@ export default function TaskPage() {
         <TaskList />
       </Suspense>
     </TaskPageContainer>
-  );
+  )
 }

--- a/supabase/functions/client.ts
+++ b/supabase/functions/client.ts
@@ -1,12 +1,26 @@
-import 'client-only'
-import { createBrowserClient } from '@supabase/ssr'
+import "client-only"
+import { createBrowserClient } from "@supabase/ssr"
 
-import { Database } from '@/types/database.types';
+import { type Database } from "@/types/database.types"
 
-// 클라이언트 컴포넌트에서 사용할 Supabase 클라이언트
+// 싱글턴 인스턴스를 저장할 변수
+let supabaseInstance: ReturnType<typeof createBrowserClient<Database>> | null = null
+
+// 싱글턴 Supabase 클라이언트 생성 함수
+const getSupabaseInstance = () => {
+  if (!supabaseInstance) {
+    supabaseInstance = createBrowserClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    )
+  }
+  return supabaseInstance
+}
+
+// 기존 createClient 호출과의 호환성을 위해 유지 (내부적으로 싱글턴 반환)
 export const createClient = () => {
-  return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
-};
+  return getSupabaseInstance()
+}
+
+// 명시적으로 싱글턴임을 나타내는 새로운 export (선택적 사용)
+export const getClient = getSupabaseInstance


### PR DESCRIPTION
Why:
- Suspense/StrictMode로 인한 잦은 마운트/언마운트에서 Realtime 채널 재생성/해제 반복 및 CLOSED 에러 노이즈 발생

What:
- supabase/functions/client.ts: createClient() 싱글턴화(전역 동일 인스턴스 재사용)
- useTaskSubscription: supabase 의존성 제거, userId/queryClient만 의존
- 정리 과정의 CLOSED를 info 로그로 격하, 오류(CHANNEL_ERROR/TIMED_OUT)만 에러 처리
- React Query 쿼리 무효화 키 유지(['receivedOrders'], ['requestedOrders'])

How:
- 싱글턴 저장 변수로 클라이언트 재사용
- cleanup 시 isCleaningUp 플래그로 로그 레벨 분기
- 구독 채널 네이밍: realtime-requests-tasklist-${userId}

Lint/Husky:
- no-explicit-any 해결: RealtimePostgresChangesPayload<RequestRow> 타입 적용
- react-hooks/exhaustive-deps 해결: supabase를 모듈 스코프 싱글턴으로 고정해 deps에서 제외

Test Plan:
- /dashboard/task?tab=received|requested 진입 시 SUBSCRIBED 1회
- 언마운트 시 CLOSED는 info로만 출력(에러 미발생)
- requests 테이블 변경 시 관련 쿼리 무효화로 리스트 갱신 확인
- task/page.tsx 동적 페이지 변경을 통한 github action build 에러 수정