### PR TITLE
[fix] : Profile 예약 모달 의뢰 생성 실패 수정 및 게임 이미지 매핑 개선

### DIFF
--- a/app/api/games/by-titles/route.ts
+++ b/app/api/games/by-titles/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { handleApiError, createValidationError } from "@/app/apis/base"
+import { gamesByTitlesGetQuerySchema } from "@/libs/schemas/server/games.schema"
+import { listGamesByDescriptions } from "@/app/apis/repository/category/gamesRepository"
+
+export async function GET(request: NextRequest) {
+  try {
+    const url = new URL(request.url)
+    const raw = Object.fromEntries(url.searchParams)
+    const parsed = gamesByTitlesGetQuerySchema.safeParse(raw)
+    if (!parsed.success) {
+      const details = parsed.error.flatten().fieldErrors
+      throw createValidationError("요청 파라미터가 유효하지 않습니다.", details)
+    }
+    const { titles } = parsed.data
+    // selected_games가 한글(설명)에 저장되어 있어 description 컬럼으로 조회
+    const games = await listGamesByDescriptions(titles)
+    return NextResponse.json({ games })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/app/apis/repository/category/gamesRepository.ts
+++ b/app/apis/repository/category/gamesRepository.ts
@@ -1,15 +1,33 @@
-'use server'
-import { getServerSupabase } from '@/app/apis/base'
+"use server"
+import { getServerSupabase } from "@/app/apis/base"
 
 export async function listGames(offset: number, limit: number) {
   const supabase = await getServerSupabase()
   const { data, error } = await supabase
-    .from('games')
-    .select('id, name, genre, description, image_url')
-    .order('name', { ascending: true })
+    .from("games")
+    .select("id, name, genre, description, image_url")
+    .order("name", { ascending: true })
     .range(offset, offset + limit - 1)
   if (error) throw error
   return data ?? []
 }
 
+export async function listGamesByNames(names: string[]) {
+  const supabase = await getServerSupabase()
+  const { data, error } = await supabase
+    .from("games")
+    .select("id, name, image_url")
+    .in("name", names)
+  if (error) throw error
+  return data ?? []
+}
 
+export async function listGamesByDescriptions(descriptions: string[]) {
+  const supabase = await getServerSupabase()
+  const { data, error } = await supabase
+    .from("games")
+    .select("id, name, description, image_url")
+    .in("description", descriptions)
+  if (error) throw error
+  return data ?? []
+}

--- a/app/apis/service/category/gamesService.ts
+++ b/app/apis/service/category/gamesService.ts
@@ -1,0 +1,7 @@
+"use server"
+import { listGamesByNames } from "@/app/apis/repository/category/gamesRepository"
+
+export async function getGamesByNames(names: string[]) {
+  // 추후 비즈니스 규칙(허용 목록, 정규화 등) 추가 여지
+  return listGamesByNames(names)
+}

--- a/app/profile/_components/ProfileGameList.tsx
+++ b/app/profile/_components/ProfileGameList.tsx
@@ -1,55 +1,62 @@
-'use client'
+"use client"
 
-import GameCard from '@/components/GameCard' // 경로 확인
-import { GameInfo, ProfileGameListProps } from '@/app/profile/_types/profile.types'
+import { useMemo } from "react"
 
-// 게임 목록 데이터 (임시 - 실제로는 API나 DB 연동 필요)
-const allGamesData: GameInfo[] = [
-   { id: 1, title: '리그 오브 레전드', image: '/images/lol2.webp' },
-   { id: 2, title: '오버워치', image: '/images/overwatch.jpg' },
-   { id: 3, title: '발로란트', image: '/images/valrorant.webp' },
-   { id: 4, title: '이터널리턴', image: '/images/eternalreturn.jpg' },
-   { id: 5, title: '피파온라인4', image: '/images/fifaonline4.webp' },
-   { id: 6, title: 'TFT', image: '/images/teamfight.avif' },
-]
+import GameCard from "@/components/GameCard"
+import type { GameInfo, ProfileGameListProps } from "@/app/profile/_types/profile.types"
+import { useGamesByTitles } from "@/hooks/api/games/useGamesByTitles"
 
-// 선택된 게임 타이틀을 전체 게임 데이터와 매핑하는 함수
-function mapSelectedGames(selectedGames: readonly string[] | null): GameInfo[] {
-    if (!selectedGames) return []
+// Next/Image 원격 허용 도메인(placehold.co)을 활용한 기본 이미지
+const DEFAULT_IMAGE = "https://placehold.co/96x96?text=Game"
 
-    return selectedGames.map((gameTitle) => {
-        const gameInfo = allGamesData.find((g) => g.title === gameTitle)
-        return (
-          gameInfo || {
-            id: gameTitle, // ID를 타이틀로 사용 (임시)
-            title: gameTitle,
-            image: '/images/default-game.webp', // 기본 이미지 지정
-          }
-        )
-     }).filter(game => game !== null) as GameInfo[] // null 제거 및 타입 단언
+// 선택된 게임 타이틀(한글, description 컬럼) 을 API 응답과 매핑하는 함수
+function mapSelectedGames(
+  selectedGames: readonly string[] | null,
+  dbGames:
+    | { id: number; name: string; description: string | null; image_url: string | null }[]
+    | undefined,
+): GameInfo[] {
+  if (!selectedGames || selectedGames.length === 0) return []
+  // DB에 한글 타이틀은 description 컬럼에 저장되어 있으므로 description 매핑
+  const byDesc = new Map((dbGames ?? []).map((g) => [g.description ?? "", g]))
+  return selectedGames.map((koreanTitle) => {
+    const row = byDesc.get(koreanTitle)
+    return {
+      id: row?.id ?? koreanTitle,
+      title: koreanTitle,
+      image: row?.image_url ?? DEFAULT_IMAGE,
+    }
+  })
 }
 
 export default function ProfileGameList({
-    selectedGames,
-    isOwner,
-    rating, // props 추가
-    reviewCount // props 추가
+  selectedGames,
+  isOwner,
+  rating,
+  reviewCount,
+  providerUserId,
 }: ProfileGameListProps) {
-  const userGames = mapSelectedGames(selectedGames)
+  // 타이틀 리스트로 게임 이미지 조회
+  const titles = useMemo(() => selectedGames ?? [], [selectedGames])
+  const { data } = useGamesByTitles(titles)
+  const userGames = useMemo(
+    () => mapSelectedGames(selectedGames, data?.games),
+    [selectedGames, data?.games],
+  )
 
   // 게임 목록 없으면 렌더링 안 함
   if (userGames.length === 0) {
-      // 또는 "플레이하는 게임이 없습니다." 메시지 표시 가능
-     return null
+    // 또는 "플레이하는 게임이 없습니다." 메시지 표시 가능
+    return null
   }
 
   // GameCard에 전달할 기본값 또는 실제 값 설정
-  const defaultRating = 0; // GameCard에서 필요한 기본값
-  const defaultReviewCount = 0; // GameCard에서 필요한 기본값
-
+  const defaultRating = 0 // GameCard에서 필요한 기본값
+  const defaultReviewCount = 0 // GameCard에서 필요한 기본값
 
   return (
     <>
+      {/* 로딩 동안에도 Skeleton 없이 즉시 렌더링하며, 이미지/가격 등은 기본값 처리 */}
       {userGames.map((game) => (
         <GameCard
           key={game.id}
@@ -57,6 +64,7 @@ export default function ProfileGameList({
           rating={rating ?? defaultRating} // 전달받은 값 또는 기본값 사용
           reviewCount={reviewCount ?? defaultReviewCount} // 전달받은 값 또는 기본값 사용
           isOwner={isOwner}
+          providerUserId={providerUserId}
         />
       ))}
     </>

--- a/app/profile/_components/ProfileMainContent.tsx
+++ b/app/profile/_components/ProfileMainContent.tsx
@@ -1,39 +1,41 @@
-"use client";
+"use client"
 
-import { useMemo } from "react";
+import { useMemo } from "react"
 
-import { ProfileMainContentProps } from "@/app/profile/_types/profile.types";
-import { useAuthStore } from "@/stores/authStore"; // isOwner 확인용
-import { usePublicProfileQuery } from "@/hooks/api/profile/usePublicProfileQuery";
+import type { ProfileMainContentProps } from "@/app/profile/_types/profile.types"
+import { useAuthStore } from "@/stores/authStore" // isOwner 확인용
+import { usePublicProfileQuery } from "@/hooks/api/profile/usePublicProfileQuery"
 
-import ProfileTabNav from "./ProfileTabNav";
-import ProfileAlbumCarousel from "./ProfileAlbumCarousel";
-import ProfileTags from "./ProfileTags";
-import ProfileGameList from "./ProfileGameList";
-import ProfileInfoSection from "./ProfileInfoSection";
-import ProfileVideoSection from "./ProfileVideoSection";
-import ProfileReviewSection from "./ProfileReviewSection";
+import ProfileTabNav from "./ProfileTabNav"
+import ProfileAlbumCarousel from "./ProfileAlbumCarousel"
+import ProfileTags from "./ProfileTags"
+import ProfileGameList from "./ProfileGameList"
+import ProfileInfoSection from "./ProfileInfoSection"
+import ProfileVideoSection from "./ProfileVideoSection"
+import ProfileReviewSection from "./ProfileReviewSection"
 
 // 탭 종류 정의
-export type ProfileTabType = "profile"; // | 'videos' | 'reviews'; // 추후 확장
+export type ProfileTabType = "profile" // | 'videos' | 'reviews'; // 추후 확장
 
 // 클라이언트 직접 페칭 로직 제거 (API+Service+Hook 레이어 사용)
 
-export default function ProfileMainContent({
-  profileId,
-}: ProfileMainContentProps) {
-  const { user: loggedInUser } = useAuthStore(); // isOwner 확인용
+export default function ProfileMainContent({ profileId }: ProfileMainContentProps) {
+  const { user: loggedInUser } = useAuthStore() // isOwner 확인용
 
   // Prefetch된 프로필 데이터 가져오기 (하위 컴포넌트에 전달 목적)
-  const numericProfileId = useMemo(() => Number(profileId), [profileId]);
-  const { data: profileData, isLoading, error } = usePublicProfileQuery(numericProfileId, {
+  const numericProfileId = useMemo(() => Number(profileId), [profileId])
+  const {
+    data: profileData,
+    isLoading,
+    error,
+  } = usePublicProfileQuery(numericProfileId, {
     enabled: Number.isFinite(numericProfileId),
     staleTime: 5 * 60 * 1000,
-  });
+  })
 
   // isOwner 계산 (GameList 등에 전달)
   // profileData가 로드된 후에 계산하도록 보장
-  const isOwner = !!profileData && loggedInUser?.id === profileData.user_id;
+  const isOwner = !!profileData && loggedInUser?.id === profileData.user_id
 
   // --- 로딩/에러 처리 ---
   // 기본적인 스켈레톤 또는 메시지 표시
@@ -60,21 +62,21 @@ export default function ProfileMainContent({
           </div>
         </div>
       </section>
-    );
+    )
   }
   if (error) {
     return (
       <section className="py-8 text-center">
         <p className="text-error">프로필 컨텐츠를 불러오는 중 오류가 발생했습니다.</p>
       </section>
-    );
+    )
   }
   if (!profileData) {
     return (
       <section className="py-8 text-center">
         <p>프로필 컨텐츠를 찾을 수 없습니다.</p>
       </section>
-    );
+    )
   }
 
   return (
@@ -106,6 +108,7 @@ export default function ProfileMainContent({
                 // TODO: rating, reviewCount 데이터 전달 필요 (실제 데이터 사용)
                 rating={5.0} // 임시 값
                 reviewCount={4} // 임시 값 (기존 page.jsx 값)
+                providerUserId={profileData.user_id}
               />
             </div>
 
@@ -124,5 +127,5 @@ export default function ProfileMainContent({
         </div>
       </section>
     </>
-  );
+  )
 }

--- a/app/profile/_types/profile.types.ts
+++ b/app/profile/_types/profile.types.ts
@@ -1,16 +1,21 @@
-import { Database } from '@/types/database.types';
-import { UsersRow, ProfilesRow, Album_imagesRow, ReviewsRow } from '@/types/database.table.types';
+import type { Database } from "@/types/database.types"
+import type {
+  UsersRow,
+  ProfilesRow,
+  Album_imagesRow,
+  ReviewsRow,
+} from "@/types/database.table.types"
 
 // 공개 프로필 데이터 타입 정의 (RLS 설정 필수)
 export type PublicProfile = Pick<
-  Database['public']['Tables']['users']['Row'], // 실제 테이블 이름 ('profiles' 등) 확인 필요
-  'id' | 'name' | 'profile_circle_img' // 공개 가능한 컬럼 (bio는 없다고 가정)
+  Database["public"]["Tables"]["users"]["Row"], // 실제 테이블 이름 ('profiles' 등) 확인 필요
+  "id" | "name" | "profile_circle_img" // 공개 가능한 컬럼 (bio는 없다고 가정)
   // 필요시 다른 공개 가능 컬럼 추가
->;
+>
 
 // 팔로우 상태 타입 (예시)
 export type FollowStatus = {
-  isFollowing: boolean;
+  isFollowing: boolean
   // 팔로워/팔로잉 수 등 추가 가능
   // followerCount?: number;
   // followingCount?: number;
@@ -18,32 +23,32 @@ export type FollowStatus = {
 
 // 비디오 데이터 타입 (예시 - 실제 구조에 맞게 수정 필요)
 export type ProfileVideoData = {
-  id: string;
-  title: string;
-  thumbnail_url: string;
-  view_count: number;
-  created_at: string;
-};
+  id: string
+  title: string
+  thumbnail_url: string
+  view_count: number
+  created_at: string
+}
 
 // Prefetch용 데이터 타입 (ProfilePageContainer)
 export type PrefetchedProfileData = Pick<
   UsersRow,
-  'id' | 'name' | 'profile_circle_img' | 'is_online'
+  "id" | "name" | "profile_circle_img" | "is_online"
 > &
   Pick<
     ProfilesRow,
-    | 'user_id' // isOwner 확인 등에 필요할 수 있음
-    | 'nickname'
-    | 'follower_count'
-    | 'description'
-    | 'selected_tags'
-    | 'youtube_urls'
-    | 'selected_games' // 게임 목록 생성에 필요
+    | "user_id" // isOwner 확인 등에 필요할 수 있음
+    | "nickname"
+    | "follower_count"
+    | "description"
+    | "selected_tags"
+    | "youtube_urls"
+    | "selected_games" // 게임 목록 생성에 필요
     // 필요에 따라 RLS 고려하여 추가
   > & { public_id: number }
 
 // 앨범 이미지 타입 (ProfileAlbumCarousel)
-export type AlbumImage = Pick<Album_imagesRow, 'id' | 'image_url' | 'order_num'> & { alt: string }
+export type AlbumImage = Pick<Album_imagesRow, "id" | "image_url" | "order_num"> & { alt: string }
 
 // 게임 정보 타입 (ProfileGameList) - 기존 games 배열 구조 활용 또는 DB 연동
 export type GameInfo = {
@@ -59,8 +64,8 @@ export type VideoInfo = {
 }
 
 // 리뷰 정보 타입 (ProfileReviewSection) - API 응답 기준
-export type ReviewInfo = Omit<ReviewsRow, 'reviewer_id' | 'reviewed_id' | 'request_id'> & {
-  reviewer: Pick<UsersRow, 'id' | 'name' | 'profile_circle_img'> | null // 작성자 정보 포함 (nullable)
+export type ReviewInfo = Omit<ReviewsRow, "reviewer_id" | "reviewed_id" | "request_id"> & {
+  reviewer: Pick<UsersRow, "id" | "name" | "profile_circle_img"> | null // 작성자 정보 포함 (nullable)
 }
 
 // ProfileHeader Props
@@ -81,7 +86,7 @@ export interface ProfileAlbumCarouselProps {
 
 // ProfileTags Props
 export interface ProfileTagsProps {
-   tags: readonly string[] | null
+  tags: readonly string[] | null
 }
 
 // ProfileGameList Props
@@ -90,6 +95,8 @@ export interface ProfileGameListProps {
   isOwner: boolean // GameCard에 전달
   rating?: number // 옵셔널로 추가 (GameCard가 옵셔널을 허용한다고 가정)
   reviewCount?: number // 옵셔널로 추가
+  // 예약 모달에서 의뢰 생성 시 제공자(user) 식별에 사용
+  providerUserId: string
 }
 
 // ProfileInfoSection Props
@@ -105,4 +112,4 @@ export interface ProfileVideoSectionProps {
 // ProfileReviewSection Props
 export interface ProfileReviewSectionProps {
   profileId: string // public_id
-} 
+}

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -1,35 +1,43 @@
-'use client';
+"use client"
 
-import { useState } from 'react';
-import Image from 'next/image';
-import { Star } from 'lucide-react';
+import { useState } from "react"
+import Image from "next/image"
+import { Star } from "lucide-react"
 
-import ReservationModal from '@/app/dashboard/chat/_components/reserveModal/ReservationModal';
+import ReservationModal from "@/app/dashboard/chat/_components/reserveModal/ReservationModal"
 
 interface GameCardProps {
   game: {
-    id: string | number;
-    title: string;
-    name?: string;
-    icon?: string;
-    image: string;
-    price?: number;
-  };
-  rating: number;
-  reviewCount: number;
-  isOwner?: boolean;
+    id: string | number
+    title: string
+    name?: string
+    icon?: string
+    image: string
+    price?: number
+  }
+  rating: number
+  reviewCount: number
+  isOwner?: boolean
+  // 프로필 소유자의 userId (의뢰 생성 시 providerId로 사용)
+  providerUserId?: string
 }
 
-export default function GameCard({ game, rating, reviewCount, isOwner = false }: GameCardProps) {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+export default function GameCard({
+  game,
+  rating,
+  reviewCount,
+  isOwner = false,
+  providerUserId,
+}: GameCardProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   const handleOpenModal = () => {
-    setIsModalOpen(true);
-  };
+    setIsModalOpen(true)
+  }
 
   const handleCloseModal = () => {
-    setIsModalOpen(false);
-  };
+    setIsModalOpen(false)
+  }
 
   return (
     <>
@@ -49,13 +57,9 @@ export default function GameCard({ game, rating, reviewCount, isOwner = false }:
               <div className="flex items-center gap-1 mt-1">
                 <div className="flex items-center gap-0.5">
                   <Star className="w-4 h-4 text-amber-500 fill-amber-500" />
-                  <span className="font-medium">
-                    {rating.toFixed(1)}
-                  </span>
+                  <span className="font-medium">{rating.toFixed(1)}</span>
                 </div>
-                <span className="text-xs text-base-content/60">
-                  ({reviewCount})
-                </span>
+                <span className="text-xs text-base-content/60">({reviewCount})</span>
               </div>
             </div>
           </div>
@@ -64,15 +68,11 @@ export default function GameCard({ game, rating, reviewCount, isOwner = false }:
             <span className="text-amber-500 font-bold">
               {game.price?.toLocaleString() || "450"}
             </span>
-            <span className="text-xs text-base-content/70">
-              /판
-            </span>
+            <span className="text-xs text-base-content/70">/판</span>
           </div>
 
           {isOwner ? (
-            <button
-              className="btn btn-block rounded-full mt-4 bg-black text-white hover:bg-gray-800"
-            >
+            <button className="btn btn-block rounded-full mt-4 bg-black text-white hover:bg-gray-800">
               수정하기
             </button>
           ) : (
@@ -88,12 +88,8 @@ export default function GameCard({ game, rating, reviewCount, isOwner = false }:
 
       {/* 예약 모달 - 각 게임 카드마다 독립적인 모달 */}
       {!isOwner && (
-        <ReservationModal
-          isOpen={isModalOpen}
-          onClose={handleCloseModal}
-          
-        />
+        <ReservationModal isOpen={isModalOpen} onClose={handleCloseModal} userId={providerUserId} />
       )}
     </>
-  );
-} 
+  )
+}

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -29,6 +29,8 @@ export const queryKeys = {
     popularGames: () => ["popular-games"] as const,
     // Games by category
     gamesByCategory: (categoryId: string) => ["gamesByCategory", categoryId] as const,
+    // Game images lookup by titles (joined key)
+    gameImagesByTitles: (titlesKey: string) => ["games", "imagesByTitles", titlesKey] as const,
   },
 
   mates: {
@@ -67,6 +69,7 @@ export type QueryKey = ReturnType<
   | typeof queryKeys.category.recommendedThemes
   | typeof queryKeys.category.popularGames
   | typeof queryKeys.category.gamesByCategory
+  | typeof queryKeys.category.gameImagesByTitles
   | typeof queryKeys.mates.recommended
   | typeof queryKeys.mates.partner
   | typeof queryKeys.chat.rooms

--- a/hooks/api/games/useGamesByTitles.ts
+++ b/hooks/api/games/useGamesByTitles.ts
@@ -1,0 +1,45 @@
+"use client"
+
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query"
+
+import { queryKeys } from "@/constants/queryKeys"
+
+export interface GamesByTitlesResponse {
+  games: Array<{ id: number; name: string; description: string | null; image_url: string | null }>
+}
+
+function buildTitlesKey(titles: readonly string[]): string {
+  return [...titles]
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean)
+    .sort()
+    .join(",")
+}
+
+export function useGamesByTitles(
+  titles: readonly string[],
+  options?: UseQueryOptions<
+    GamesByTitlesResponse,
+    Error,
+    GamesByTitlesResponse,
+    ReturnType<typeof queryKeys.category.gameImagesByTitles>
+  >,
+) {
+  const titlesKey = buildTitlesKey(titles)
+  return useQuery({
+    queryKey: queryKeys.category.gameImagesByTitles(titlesKey),
+    queryFn: async () => {
+      const qs = new URLSearchParams({ titles: titles.join(",") })
+      const res = await fetch(`/api/games/by-titles?${qs.toString()}`)
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err?.error || "게임 이미지를 가져오는데 실패했습니다")
+      }
+      return (await res.json()) as GamesByTitlesResponse
+    },
+    enabled: titles.length > 0,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    ...options,
+  })
+}

--- a/libs/schemas/server/games.schema.ts
+++ b/libs/schemas/server/games.schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+// GET /api/games/by-titles?titles=LOL,OW,VAL
+export const gamesByTitlesGetQuerySchema = z.object({
+  titles: z.preprocess(
+    (v) => {
+      if (typeof v === "string") {
+        return v
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      }
+      return []
+    },
+    z
+      .array(z.string().min(1))
+      .min(1, { message: "titles는 최소 1개 이상이어야 합니다." })
+      .max(20, { message: "titles는 최대 20개까지 허용됩니다." }),
+  ),
+})
+
+export type GamesByTitlesGetQuery = z.infer<typeof gamesByTitlesGetQuerySchema>


### PR DESCRIPTION
Why: providerId 미전달로 verify 실패, 한글 타이틀을 name(영문)으로 조회하여 이미지 매핑 실패

What: providerUserId 전달 체인 추가, /api/games/by-titles 신설, description 기준 조회, useGamesByTitles 추가, ProfileGameList 리팩터링

How: types/props/쿼리키/훅/라우트/레포지토리 추가 및 수정(표준 에러 처리/검증 포함)

Test: 프로필 카드 썸네일 표시, 예약/결제 플로우 200, by-titles API 200, 린트/프리커밋 통과

Impact: Breaking 없음, 예약 안정성 및 이미지 로딩 개선