### PR TITLE
[fix] : MainCarousel 사용처 Query키 분리

### DIFF
--- a/app/api/profile/public/album/route.ts
+++ b/app/api/profile/public/album/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { handleApiError, createValidationError } from "@/app/apis/base"
+import { getAlbumGalleryByUserIdPublic } from "@/app/apis/service/profile/albumService"
+
+// GET /api/profile/public/album?userId=<string>
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url)
+    const raw = Object.fromEntries(url.searchParams)
+
+    const schema = z.object({
+      userId: z
+        .string({ required_error: "userId는 필수입니다." })
+        .min(1, { message: "userId는 비어 있을 수 없습니다." }),
+    })
+
+    const parsed = schema.safeParse(raw)
+    if (!parsed.success) {
+      const details = parsed.error.flatten().fieldErrors
+      throw createValidationError("요청 파라미터가 유효하지 않습니다.", details)
+    }
+
+    const { userId } = parsed.data
+    const { formatted, thumbnailIndex } = await getAlbumGalleryByUserIdPublic(userId)
+
+    return NextResponse.json({ success: true, data: formatted, thumbnailIndex }, { status: 200 })
+  } catch (err) {
+    return handleApiError(err)
+  }
+}

--- a/app/apis/service/profile/albumService.ts
+++ b/app/apis/service/profile/albumService.ts
@@ -1,5 +1,5 @@
-'use server'
-import { getCurrentUserId } from '@/app/apis/base/auth'
+"use server"
+import { getCurrentUserId } from "@/app/apis/base/auth"
 import {
   deleteAlbumImageRecord,
   getExistingAlbumImage,
@@ -10,7 +10,7 @@ import {
   removeFromAlbumBucket,
   updateUserThumbnail,
   uploadToAlbumBucket,
-} from '@/app/apis/repository/profile/albumRepository'
+} from "@/app/apis/repository/profile/albumRepository"
 
 export async function getAlbumGallery() {
   const userId = await getCurrentUserId()
@@ -18,7 +18,34 @@ export async function getAlbumGallery() {
     listAlbumImages(userId),
     getUserThumbnail(userId),
   ])
-  const formatted = Array(6).fill(null) as Array<{ id: string; url: string; isThumbnail: boolean } | null>
+  const formatted = Array(6).fill(null) as Array<{
+    id: string
+    url: string
+    isThumbnail: boolean
+  } | null>
+  let thumbnailIndex: number | null = null
+  images.forEach((img) => {
+    if (img.order_num >= 0 && img.order_num < 6) {
+      const isThumb = img.image_url === thumbnailUrl
+      formatted[img.order_num] = { id: img.id, url: img.image_url, isThumbnail: isThumb }
+      if (isThumb) thumbnailIndex = img.order_num
+    }
+  })
+  return { formatted, thumbnailIndex }
+}
+
+// 공개 프로필 조회용: 특정 사용자(userId)의 앨범 갤러리를 반환
+// 인증에 의존하지 않고 매개변수로 받은 userId로만 조회합니다.
+export async function getAlbumGalleryByUserIdPublic(userId: string) {
+  const [images, thumbnailUrl] = await Promise.all([
+    listAlbumImages(userId),
+    getUserThumbnail(userId),
+  ])
+  const formatted = Array(6).fill(null) as Array<{
+    id: string
+    url: string
+    isThumbnail: boolean
+  } | null>
   let thumbnailIndex: number | null = null
   images.forEach((img) => {
     if (img.order_num >= 0 && img.order_num < 6) {
@@ -32,11 +59,11 @@ export async function getAlbumGallery() {
 
 export async function uploadAlbumImage(formData: FormData) {
   const userId = await getCurrentUserId()
-  const file = formData.get('file') as File | null
-  const indexStr = formData.get('index') as string | null
-  if (!file || indexStr === null) throw new Error('필수 정보(파일, 인덱스)가 누락되었습니다.')
+  const file = formData.get("file") as File | null
+  const indexStr = formData.get("index") as string | null
+  if (!file || indexStr === null) throw new Error("필수 정보(파일, 인덱스)가 누락되었습니다.")
   const index = parseInt(indexStr, 10)
-  if (isNaN(index) || index < 0 || index > 5) throw new Error('유효하지 않은 인덱스입니다.')
+  if (isNaN(index) || index < 0 || index > 5) throw new Error("유효하지 않은 인덱스입니다.")
 
   const existing = await getExistingAlbumImage(userId, index)
   const { publicUrl, filePath } = await uploadToAlbumBucket(userId, file, index)
@@ -46,7 +73,7 @@ export async function uploadAlbumImage(formData: FormData) {
       await deleteAlbumImageRecord(existing.id)
     } catch {}
     try {
-      const oldPath = existing.image_url.split('albums/')[1]
+      const oldPath = existing.image_url.split("albums/")[1]
       if (oldPath) await removeFromAlbumBucket(oldPath)
     } catch {}
   }
@@ -60,13 +87,13 @@ export async function deleteAlbumImage(imageId: string) {
   // 읽기
   const images = await listAlbumImages(userId)
   const target = images.find((i) => i.id === imageId)
-  if (!target) throw new Error('삭제할 이미지를 찾을 수 없습니다.')
+  if (!target) throw new Error("삭제할 이미지를 찾을 수 없습니다.")
   const currentThumb = await getUserThumbnail(userId)
   const wasThumb = target.image_url === currentThumb
   // 삭제
   await deleteAlbumImageRecord(target.id)
   try {
-    const path = target.image_url.split('albums/')[1]
+    const path = target.image_url.split("albums/")[1]
     if (path) await removeFromAlbumBucket(path)
   } catch {}
   // 썸네일 재설정
@@ -80,9 +107,7 @@ export async function deleteAlbumImage(imageId: string) {
 
 export async function setThumbnail(imageUrl: string) {
   const userId = await getCurrentUserId()
-  if (!imageUrl) throw new Error('이미지 URL이 누락되었습니다.')
+  if (!imageUrl) throw new Error("이미지 URL이 누락되었습니다.")
   await updateUserThumbnail(userId, imageUrl)
   return { newThumbnailUrl: imageUrl }
 }
-
-

--- a/app/dashboard/_api/profileSectionApi.ts
+++ b/app/dashboard/_api/profileSectionApi.ts
@@ -1,32 +1,32 @@
-import { ProfileDataSchema } from '@/libs/schemas/profile.schema';
+import { ProfileDataSchema } from "@/libs/schemas/profile.schema"
 
 // 타입 재내보내기
-export type { ProfileDataSchema };
+export type { ProfileDataSchema }
 
 /**
  * 프로필 정보를 가져오는 함수
  */
 export async function fetchProfileInfo(): Promise<ProfileDataSchema> {
   try {
-    const response = await fetch('/api/profile/info');
-    
+    const response = await fetch("/api/profile/info")
+
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error || '프로필 정보를 불러오는데 실패했습니다');
+      const errorData = await response.json()
+      throw new Error(errorData.error || "프로필 정보를 불러오는데 실패했습니다")
     }
-    
-    const { profileData } = await response.json();
-    
+
+    const { profileData } = await response.json()
+
     // API 응답 (responsePayload)를 클라이언트에서 사용할 형태로 반환
     // profileData가 null일 경우 기본값 처리 강화
     const defaultData: Partial<ProfileDataSchema> = {
-        nickname: '',
-        username: '',
-        description: '',
-        selected_games: [],
-        selected_tags: [],
-        youtube_urls: [],
-        is_mate: false,
+      nickname: "",
+      username: "",
+      description: "",
+      selected_games: [],
+      selected_tags: [],
+      youtube_urls: [],
+      is_mate: false,
     }
 
     return {
@@ -34,10 +34,28 @@ export async function fetchProfileInfo(): Promise<ProfileDataSchema> {
       ...(profileData || {}), // API에서 받은 데이터 덮어쓰기 (null일 경우 빈 객체)
       // DB 필드명과 클라이언트 필드명이 다를 경우 여기서 매핑
       // 예: introduction: profileData?.description ?? ''
-    };
+    }
   } catch (error) {
-    console.error('프로필 정보 로드 오류:', error);
-    throw error; // 에러를 다시 throw하여 useQuery에서 처리
+    console.error("프로필 정보 로드 오류:", error)
+    throw error // 에러를 다시 throw하여 useQuery에서 처리
+  }
+}
+
+/**
+ * 공개 프로필(특정 userId)의 앨범 이미지 목록 조회 함수
+ */
+export async function fetchPublicAlbumImages(userId: string) {
+  try {
+    const response = await fetch(`/api/profile/public/album?userId=${encodeURIComponent(userId)}`)
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => ({}))) as any
+      throw new Error(errorData.error || "공개 앨범 이미지를 불러오는데 실패했습니다")
+    }
+    const { data, thumbnailIndex } = await response.json()
+    return { images: data, thumbnailIndex }
+  } catch (error) {
+    console.error("공개 앨범 이미지 로드 오류:", error)
+    throw error
   }
 }
 
@@ -46,10 +64,10 @@ export async function fetchProfileInfo(): Promise<ProfileDataSchema> {
  */
 export async function updateProfileInfo(profileData: Partial<ProfileDataSchema>) {
   try {
-    const response = await fetch('/api/profile/info', {
-      method: 'POST',
+    const response = await fetch("/api/profile/info", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       // 전송할 데이터에 username 포함
       body: JSON.stringify({
@@ -61,18 +79,18 @@ export async function updateProfileInfo(profileData: Partial<ProfileDataSchema>)
         youtube_urls: profileData.youtube_urls,
         is_mate: profileData.is_mate,
       }),
-    });
-    
+    })
+
     if (!response.ok) {
-      const errorData = await response.json();
+      const errorData = await response.json()
       // 서버에서 보낸 상세 에러 메시지 사용
-      throw new Error(errorData.error || '프로필 정보를 저장하는데 실패했습니다');
+      throw new Error(errorData.error || "프로필 정보를 저장하는데 실패했습니다")
     }
-    
-    return await response.json();
+
+    return await response.json()
   } catch (error) {
-    console.error('프로필 저장 오류:', error);
-    throw error; // 에러를 다시 throw하여 useMutation에서 처리
+    console.error("프로필 저장 오류:", error)
+    throw error // 에러를 다시 throw하여 useMutation에서 처리
   }
 }
 
@@ -81,18 +99,18 @@ export async function updateProfileInfo(profileData: Partial<ProfileDataSchema>)
  */
 export async function fetchProfileImage() {
   try {
-    const response = await fetch('/api/profile/image/profileImage');
-    
+    const response = await fetch("/api/profile/image/profileImage")
+
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error || '프로필 이미지를 불러오는데 실패했습니다');
+      const errorData = await response.json()
+      throw new Error(errorData.error || "프로필 이미지를 불러오는데 실패했습니다")
     }
-    
-    const { data } = await response.json();
-    return data;
+
+    const { data } = await response.json()
+    return data
   } catch (error) {
-    console.error('프로필 이미지 로드 오류:', error);
-    throw error;
+    console.error("프로필 이미지 로드 오류:", error)
+    throw error
   }
 }
 
@@ -101,23 +119,23 @@ export async function fetchProfileImage() {
  */
 export async function updateProfileImage(imageUrl: string) {
   try {
-    const response = await fetch('/api/profile/image/profileImage', {
-      method: 'POST',
+    const response = await fetch("/api/profile/image/profileImage", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({ imageUrl }),
-    });
-    
+    })
+
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error || '프로필 이미지를 업데이트하는데 실패했습니다');
+      const errorData = await response.json()
+      throw new Error(errorData.error || "프로필 이미지를 업데이트하는데 실패했습니다")
     }
-    
-    return await response.json();
+
+    return await response.json()
   } catch (error) {
-    console.error('프로필 이미지 업데이트 오류:', error);
-    throw error;
+    console.error("프로필 이미지 업데이트 오류:", error)
+    throw error
   }
 }
 
@@ -126,24 +144,24 @@ export async function updateProfileImage(imageUrl: string) {
  */
 export async function uploadFileToStorage(file: File) {
   try {
-    const formData = new FormData();
-    formData.append('file', file);
-    
-    const response = await fetch('/api/storage/upload', {
-      method: 'POST',
+    const formData = new FormData()
+    formData.append("file", file)
+
+    const response = await fetch("/api/storage/upload", {
+      method: "POST",
       body: formData,
-    });
-    
+    })
+
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error || '파일 업로드에 실패했습니다');
+      const errorData = await response.json()
+      throw new Error(errorData.error || "파일 업로드에 실패했습니다")
     }
-    
-    const { data } = await response.json();
-    return data.url;
+
+    const { data } = await response.json()
+    return data.url
   } catch (error) {
-    console.error('파일 업로드 오류:', error);
-    throw error;
+    console.error("파일 업로드 오류:", error)
+    throw error
   }
 }
 
@@ -152,16 +170,16 @@ export async function uploadFileToStorage(file: File) {
  */
 export async function fetchAlbumImages() {
   try {
-    const response = await fetch('/api/profile/image/image_gallery');
+    const response = await fetch("/api/profile/image/image_gallery")
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error || '앨범 이미지를 불러오는데 실패했습니다');
+      const errorData = await response.json()
+      throw new Error(errorData.error || "앨범 이미지를 불러오는데 실패했습니다")
     }
-    const { data, thumbnailIndex } = await response.json();
-    return { images: data, thumbnailIndex }; // 서버 응답 구조에 맞게 반환
+    const { data, thumbnailIndex } = await response.json()
+    return { images: data, thumbnailIndex } // 서버 응답 구조에 맞게 반환
   } catch (error) {
-    console.error('앨범 이미지 로드 오류:', error);
-    throw error;
+    console.error("앨범 이미지 로드 오류:", error)
+    throw error
   }
 }
 
@@ -170,25 +188,25 @@ export async function fetchAlbumImages() {
  */
 export async function uploadAlbumImage(file: File, index: number) {
   try {
-    const formData = new FormData();
-    formData.append('file', file);
-    formData.append('index', index.toString());
+    const formData = new FormData()
+    formData.append("file", file)
+    formData.append("index", index.toString())
 
-    const response = await fetch('/api/profile/image/image_gallery', {
-      method: 'POST',
+    const response = await fetch("/api/profile/image/image_gallery", {
+      method: "POST",
       body: formData,
-    });
+    })
 
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error || '앨범 이미지 업로드에 실패했습니다');
+      const errorData = await response.json()
+      throw new Error(errorData.error || "앨범 이미지 업로드에 실패했습니다")
     }
 
-    const { data } = await response.json();
-    return data; // 업로드된 이미지 정보 반환
+    const { data } = await response.json()
+    return data // 업로드된 이미지 정보 반환
   } catch (error) {
-    console.error('앨범 이미지 업로드 오류:', error);
-    throw error;
+    console.error("앨범 이미지 업로드 오류:", error)
+    throw error
   }
 }
 
@@ -197,23 +215,23 @@ export async function uploadAlbumImage(file: File, index: number) {
  */
 export async function deleteAlbumImage(imageId: string) {
   try {
-    const response = await fetch('/api/profile/image/image_gallery', {
-      method: 'DELETE',
+    const response = await fetch("/api/profile/image/image_gallery", {
+      method: "DELETE",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({ imageId }),
-    });
+    })
 
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error || '앨범 이미지 삭제에 실패했습니다');
+      const errorData = await response.json()
+      throw new Error(errorData.error || "앨범 이미지 삭제에 실패했습니다")
     }
 
-    return await response.json(); // 삭제 결과 및 새 썸네일 정보 반환
+    return await response.json() // 삭제 결과 및 새 썸네일 정보 반환
   } catch (error) {
-    console.error('앨범 이미지 삭제 오류:', error);
-    throw error;
+    console.error("앨범 이미지 삭제 오류:", error)
+    throw error
   }
 }
 
@@ -222,22 +240,22 @@ export async function deleteAlbumImage(imageId: string) {
  */
 export async function setAlbumImageAsThumbnail(imageUrl: string) {
   try {
-    const response = await fetch('/api/profile/image/image_gallery', {
-      method: 'PATCH',
+    const response = await fetch("/api/profile/image/image_gallery", {
+      method: "PATCH",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({ imageUrl }),
-    });
+    })
 
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error || '썸네일 설정에 실패했습니다');
+      const errorData = await response.json()
+      throw new Error(errorData.error || "썸네일 설정에 실패했습니다")
     }
 
-    return await response.json(); // 새 썸네일 정보 반환
+    return await response.json() // 새 썸네일 정보 반환
   } catch (error) {
-    console.error('썸네일 설정 오류:', error);
-    throw error;
+    console.error("썸네일 설정 오류:", error)
+    throw error
   }
 }

--- a/app/profile/_components/ProfileAlbumCarousel.tsx
+++ b/app/profile/_components/ProfileAlbumCarousel.tsx
@@ -1,16 +1,16 @@
 "use client"
 
-import { useAlbumImagesQuery } from "@/hooks/api/profile/useAlbumQueries"
+import { usePublicAlbumImagesQuery } from "@/hooks/api/profile/useAlbumQueries"
 
 import MainCarousel from "@/app/(home)/_components/MainCarousel"
 import { ProfileAlbumCarouselProps } from "@/app/profile/_types/profile.types"
 
 export default function ProfileAlbumCarousel({
-  userId: _userId,
+  userId,
   profileNickname,
 }: ProfileAlbumCarouselProps) {
-  // 앨범 이미지 데이터 Fetch (중앙 훅 사용)
-  const { data, isLoading, error } = useAlbumImagesQuery()
+  // 공개 프로필(userId 기준) 앨범 이미지 데이터 Fetch (사용자별 캐시 키)
+  const { data, isLoading, error } = usePublicAlbumImagesQuery(userId)
 
   // 로딩 또는 이미지 없는 경우 렌더링 안 함
   if (isLoading || error || !data?.images || data.images.every((v) => v == null)) {

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -51,6 +51,9 @@ export const queryKeys = {
     info: () => ["profileInfo"] as const,
     image: () => ["profileImage"] as const,
     albumImages: () => ["albumImages"] as const,
+    // 공개 프로필 앨범 이미지(사용자별 캐시 분리)
+    albumImagesPublic: (publicUserId: string | number) =>
+      ["albumImagesPublic", String(publicUserId)] as const,
     publicById: (publicId: number) => ["profilePublic", publicId] as const,
   },
 } as const
@@ -80,6 +83,7 @@ export type QueryKey = ReturnType<
   | typeof queryKeys.profile.info
   | typeof queryKeys.profile.image
   | typeof queryKeys.profile.albumImages
+  | typeof queryKeys.profile.albumImagesPublic
   | typeof queryKeys.profile.publicById
 >
 

--- a/hooks/api/profile/useAlbumQueries.ts
+++ b/hooks/api/profile/useAlbumQueries.ts
@@ -3,7 +3,7 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query"
 
 import { queryKeys } from "@/constants/queryKeys"
-import { fetchAlbumImages } from "@/app/dashboard/_api/profileSectionApi"
+import { fetchAlbumImages, fetchPublicAlbumImages } from "@/app/dashboard/_api/profileSectionApi"
 
 interface AlbumImagesData {
   images: any[]
@@ -11,7 +11,12 @@ interface AlbumImagesData {
 }
 
 export function useAlbumImagesQuery(
-  options?: UseQueryOptions<AlbumImagesData, Error, AlbumImagesData, ReturnType<typeof queryKeys.profile.albumImages>>
+  options?: UseQueryOptions<
+    AlbumImagesData,
+    Error,
+    AlbumImagesData,
+    ReturnType<typeof queryKeys.profile.albumImages>
+  >,
 ) {
   return useQuery({
     queryKey: queryKeys.profile.albumImages(),
@@ -22,3 +27,22 @@ export function useAlbumImagesQuery(
   })
 }
 
+// 특정 사용자(userId)의 공개 프로필 앨범 이미지를 조회하는 훅
+export function usePublicAlbumImagesQuery(
+  userId: string,
+  options?: UseQueryOptions<
+    AlbumImagesData,
+    Error,
+    AlbumImagesData,
+    ReturnType<typeof queryKeys.profile.albumImagesPublic>
+  >,
+) {
+  return useQuery({
+    queryKey: queryKeys.profile.albumImagesPublic(userId),
+    queryFn: () => fetchPublicAlbumImages(userId),
+    enabled: !!userId,
+    staleTime: 300_000, // 5분
+    refetchOnWindowFocus: false,
+    ...options,
+  })
+}


### PR DESCRIPTION
Why: 프로필 상세와 대시보드가 동일 키(albumImages)로 캐시 충돌 → 먼저 로드된 유저 이미지가 잔존

What: 쿼리 키(albumImagesPublic(userId)) 추가, 공개용 서비스/라우트/훅/Fetcher 추가, 캐러셀 훅 전환

How: queryKeys/albumService/API route/fetcher/hook/ProfileAlbumCarousel 수정

Test: /profile/2 → /dashboard?tab=profile 이동 시 이미지 섞임 재현되지 않음, 네트워크 라우트 분리 확인

Impact: 데이터 오염 방지 및 안정성 개선