### PR TITLE
[refactor] : Profile GameSelectionCard가 DB games 사용 + 6개/페이지 클라 페이징

### DIFF
--- a/app/api/games/all/route.ts
+++ b/app/api/games/all/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server"
+
+import { handleApiError } from "@/app/apis/base"
+import { listAllGames } from "@/app/apis/repository/category/gamesRepository"
+
+export async function GET() {
+  try {
+    const games = await listAllGames()
+    return NextResponse.json({ games })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/app/apis/repository/category/gamesRepository.ts
+++ b/app/apis/repository/category/gamesRepository.ts
@@ -31,3 +31,13 @@ export async function listGamesByDescriptions(descriptions: string[]) {
   if (error) throw error
   return data ?? []
 }
+
+export async function listAllGames() {
+  const supabase = await getServerSupabase()
+  const { data, error } = await supabase
+    .from("games")
+    .select("id, name, description, image_url")
+    .order("name", { ascending: true })
+  if (error) throw error
+  return data ?? []
+}

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -2,6 +2,10 @@
 // Keep compatibility first; normalize later during refactors
 
 export const queryKeys = {
+  games: {
+    // 전체 게임 목록
+    all: () => ["games", "all"] as const,
+  },
   token: {
     // Header token display uses ['tokenBalance', userId]
     balanceHeader: (userId: string) => ["token", "balanceHeader", userId] as const,
@@ -59,6 +63,7 @@ export const queryKeys = {
 } as const
 
 export type QueryKey = ReturnType<
+  | typeof queryKeys.games.all
   | typeof queryKeys.token.balanceHeader
   | typeof queryKeys.token.balance
   | typeof queryKeys.token.usage

--- a/hooks/api/games/useAllGames.ts
+++ b/hooks/api/games/useAllGames.ts
@@ -1,0 +1,28 @@
+"use client"
+
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query"
+
+import { queryKeys } from "@/constants/queryKeys"
+import { fetchJson } from "@/libs/api/fetchJson"
+import type { GamesRow } from "@/types/database.table.types"
+
+export interface AllGamesResponse {
+  games: GamesRow[]
+}
+
+export function useAllGames(
+  options?: UseQueryOptions<
+    AllGamesResponse,
+    Error,
+    AllGamesResponse,
+    ReturnType<typeof queryKeys.games.all>
+  >,
+) {
+  return useQuery({
+    queryKey: queryKeys.games.all(),
+    queryFn: async () => fetchJson<AllGamesResponse>("/api/games/all"),
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    ...options,
+  })
+}


### PR DESCRIPTION

Why: 
- 하드코딩 제거 및 데이터 단일 출처 확보
- selected_games(한글명)과 DB(games.description) 기준 일관화
- 데이터량이 적어 서버 페이지네이션 없이 클라 페이징이 합리적" \
  
What:
- queryKeys.games.all 추가
- repository listAllGames 추가(id, name, description, image_url)
- API GET /api/games/all 추가(handleApiError)
- hook useAllGames 추가
- GameSelectionCard: DB 연동, 6개/페이지 페이징, 로딩/에러 처리" \

How :
- constants/queryKeys.ts: games.all 키/타입 추가
- app/apis/repository/category/gamesRepository.ts: listAllGames()
- app/api/games/all/route.ts: 전체 목록 반환
- hooks/api/games/useAllGames.ts: React Query 훅
- app/dashboard/_components/profileSection/components/infoSection/GameSelectionCard.tsx:
  description→title, image_url→image 매핑, 선택/토글 로직 유지, 에러/로딩 UI

Test Plan :
1) 프로필 편집 > 게임 추가하기 확장 시 스켈레톤 표시
2) 목록 로딩 후 6개 표시, 이전/다음으로 페이지 전환(선택 상태 유지)
3) 카드 클릭 시 선택/해제되고 상단 그리드 반영
4) image_url 없을 때 폴백 이미지 표시
5) 네트워크 오류 시 에러 메시지 노출

Impact :
- Breaking changes: 없음
- 데이터 일관성/유지보수성 개선, 캐시 키 표준화