### PR TITLE
[refactor] : ReservationModal가 provider의 selected_games 기반으로 게임 구성 및 is_mate 교차 검증 추가

### DIFF
--- a/app/api/profile/selected-games/route.ts
+++ b/app/api/profile/selected-games/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { handleApiError, createValidationError } from "@/app/apis/base"
+import { getProfileByUserId } from "@/app/apis/repository/profile/profilesRepository"
+import { profileSelectedGamesGetQuerySchema } from "@/libs/schemas/server/profile.schema"
+
+export async function GET(req: NextRequest) {
+  try {
+    const raw = Object.fromEntries(new URL(req.url).searchParams)
+    const parsed = profileSelectedGamesGetQuerySchema.safeParse(raw)
+    if (!parsed.success) {
+      const details = parsed.error.flatten().fieldErrors
+      throw createValidationError("요청 파라미터가 유효하지 않습니다.", details)
+    }
+    const { userId } = parsed.data
+
+    const profile = await getProfileByUserId(userId)
+    const selectedGames = profile?.selected_games ?? []
+    return NextResponse.json({ selectedGames })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/app/dashboard/_components/profileSection/components/infoSection/GameSelectionCard.tsx
+++ b/app/dashboard/_components/profileSection/components/infoSection/GameSelectionCard.tsx
@@ -3,9 +3,9 @@
 import React, { useState, useCallback } from "react"
 import Image from "next/image"
 import { Plus, X, ChevronDown, Check } from "lucide-react"
-import { useFormContext, Controller, ControllerRenderProps } from "react-hook-form"
+import { useFormContext, Controller, type ControllerRenderProps } from "react-hook-form"
 
-import { ProfileDataSchema } from "@/libs/schemas/profile.schema"
+import { type ProfileDataSchema } from "@/libs/schemas/profile.schema"
 import { useAllGames } from "@/hooks/api/games/useAllGames"
 
 // 페이지 사이즈 상수 (클라이언트 페이징)
@@ -98,7 +98,12 @@ const GameSelectionCard = React.memo(({ name }: GameSelectionCardProps) => {
                     <div key={game.id} className="card bg-base-200 relative">
                       <div className="card-body p-3">
                         <div className="w-full aspect-video relative rounded-lg overflow-hidden mb-2">
-                          <Image src={game.image} alt={game.title} fill className="object-cover" />
+                          <Image
+                            src={game.image}
+                            alt={game.title}
+                            fill
+                            className="object-cover object-bottom"
+                          />
                           <button
                             type="button"
                             onClick={() => removeGame(game.title)}
@@ -180,7 +185,12 @@ const GameSelectionCard = React.memo(({ name }: GameSelectionCardProps) => {
                           }`}
                           onClick={() => toggleGameSelection(game.title)}
                         >
-                          <Image src={game.image} alt={game.title} fill className="object-cover" />
+                          <Image
+                            src={game.image}
+                            alt={game.title}
+                            fill
+                            className="object-cover object-bottom"
+                          />
                           {selectedGamesValue.includes(game.title) && (
                             <div className="absolute top-2 right-2 bg-yellow-400 rounded-full p-1">
                               <Check className="w-4 h-4 text-white" />

--- a/app/dashboard/chat/_components/reserveModal/ReservationModal.tsx
+++ b/app/dashboard/chat/_components/reserveModal/ReservationModal.tsx
@@ -1,58 +1,91 @@
-"use client";
+"use client"
 
-import { useState, useMemo, useEffect, useCallback } from "react";
-import "react-datepicker/dist/react-datepicker.css";
-import { useQuery , useMutation } from "@tanstack/react-query";
-import { X } from "lucide-react";
-import {
-  isSameDay,
-  isAfter,
-  isSameHour,
-  isSameMinute,
-} from "date-fns";
-import dynamic from 'next/dynamic';
+import { useState, useMemo, useEffect, useCallback } from "react"
+import "react-datepicker/dist/react-datepicker.css"
+import { useQuery, useMutation } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { isSameDay, isAfter, isSameHour, isSameMinute } from "date-fns"
+import dynamic from "next/dynamic"
 
-import { orderApi } from "@/app/dashboard/_api/orderApi";
+import { orderApi } from "@/app/dashboard/_api/orderApi"
 
 // 타입과 컴포넌트 가져오기
-import { 
-  ReservationModalProps, 
-  ReservationOrder, 
-  ProviderOrdersResponse, 
+import {
+  ReservationModalProps,
+  ReservationOrder,
+  ProviderOrdersResponse,
   Reservation,
-  Game
-} from "./types";
-import { games } from "./data";
-import { formatDate } from "./utils";
+  Game,
+} from "./types"
+import { useGamesByTitles } from "@/hooks/api/games/useGamesByTitles"
+import { queryKeys } from "@/constants/queryKeys"
+import { fetchJson } from "@/libs/api/fetchJson"
+import { formatDate } from "./utils"
 
 // 동적 로딩 적용
-const DateTimeSelector = dynamic(() => import('./DateTimeSelector').then(mod => ({ default: mod.DateTimeSelector })), { 
-  ssr: false,
-  loading: () => (
-    <div className="flex justify-center items-center p-4">
-      <div className="loading loading-spinner loading-md text-primary"></div>
-    </div>
-  ) 
-});
-const ReservationList = dynamic(() => import('./ReservationList').then(mod => ({ default: mod.ReservationList })), { ssr: false });
-const GameSelector = dynamic(() => import('./GameSelector').then(mod => ({ default: mod.GameSelector })), { ssr: false });
-const ReservationSummary = dynamic(() => import('./ReservationSummary').then(mod => ({ default: mod.ReservationSummary })), { ssr: false });
-const PaymentInfo = dynamic(() => import('./PaymentInfo').then(mod => ({ default: mod.PaymentInfo })), { ssr: false });
+const DateTimeSelector = dynamic(
+  () => import("./DateTimeSelector").then((mod) => ({ default: mod.DateTimeSelector })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex justify-center items-center p-4">
+        <div className="loading loading-spinner loading-md text-primary"></div>
+      </div>
+    ),
+  },
+)
+const ReservationList = dynamic(
+  () => import("./ReservationList").then((mod) => ({ default: mod.ReservationList })),
+  { ssr: false },
+)
+const GameSelector = dynamic(
+  () => import("./GameSelector").then((mod) => ({ default: mod.GameSelector })),
+  { ssr: false },
+)
+const ReservationSummary = dynamic(
+  () => import("./ReservationSummary").then((mod) => ({ default: mod.ReservationSummary })),
+  { ssr: false },
+)
+const PaymentInfo = dynamic(
+  () => import("./PaymentInfo").then((mod) => ({ default: mod.PaymentInfo })),
+  { ssr: false },
+)
 
-export default function ReservationModal({
-  isOpen,
-  onClose,
-  userId,
-}: ReservationModalProps) {
+export default function ReservationModal({ isOpen, onClose, userId }: ReservationModalProps) {
   // 날짜와 시간 상태 분리
-  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
-  const [selectedTime, setSelectedTime] = useState<Date | null>(null);
-  const [availableTimes, setAvailableTimes] = useState<Date[]>([]);
-  
-  const [selectedGame, setSelectedGame] = useState<Game | null>(null);
-  const [reservations, setReservations] = useState<Reservation[]>([]);
-  const [phase, setPhase] = useState<"select" | "payment">("select");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date())
+  const [selectedTime, setSelectedTime] = useState<Date | null>(null)
+  const [availableTimes, setAvailableTimes] = useState<Date[]>([])
+
+  const [selectedGame, setSelectedGame] = useState<Game | null>(null)
+  const [reservations, setReservations] = useState<Reservation[]>([])
+  const [phase, setPhase] = useState<"select" | "payment">("select")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // 제공자(provider)의 selected_games를 조회
+  const { data: selectedGamesResp, isLoading: isLoadingSelectedGames } = useQuery<{
+    selectedGames: string[]
+  }>({
+    queryKey: userId
+      ? queryKeys.profile.selectedGamesByUserId(userId)
+      : (["profile", "selectedGames", "unknown"] as const),
+    queryFn: async () =>
+      fetchJson<{ selectedGames: string[] }>(
+        `/api/profile/selected-games?userId=${encodeURIComponent(userId!)}`,
+      ),
+    enabled: !!userId && isOpen,
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const titles = (selectedGamesResp?.selectedGames ?? []).map((t) => t.trim()).filter(Boolean)
+  const { data: titlesData, isLoading: isLoadingTitles } = useGamesByTitles(titles)
+
+  // GameSelector가 기대하는 Game 타입으로 매핑
+  const mappedProviderGames: Game[] = (titlesData?.games ?? []).map((g) => ({
+    id: g.id,
+    game: g.description ?? g.name, // 한글명 우선
+    image: g.image_url ?? "https://placehold.co/640x360?text=Game",
+  }))
 
   // Tanstack Query를 사용하여 기존 예약 정보 가져오기
   const {
@@ -63,138 +96,134 @@ export default function ReservationModal({
   } = useQuery<ProviderOrdersResponse>({
     queryKey: ["providerReservations", userId],
     queryFn: async () => {
-      if (!userId) return { orders: [] };
-      const response = await orderApi.getProviderReservations(userId);
-      return response as unknown as ProviderOrdersResponse;
+      if (!userId) return { orders: [] }
+      const response = await orderApi.getProviderReservations(userId)
+      return response as unknown as ProviderOrdersResponse
     },
     enabled: !!userId && isOpen, // userId가 있고 모달이 열렸을 때만 실행
     staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
-  });
+  })
 
   // 기존 예약 시간을 Date 객체의 배열로 변환
   const existingReservations = useMemo(() => {
-    if (!existingReservationsData?.orders) return [];
+    if (!existingReservationsData?.orders) return []
 
     return existingReservationsData.orders.map((order: ReservationOrder) => {
-      return new Date(`${order.scheduled_date}T${order.scheduled_time}`);
-    });
-  }, [existingReservationsData]);
+      return new Date(`${order.scheduled_date}T${order.scheduled_time}`)
+    })
+  }, [existingReservationsData])
 
   // 모달이 열릴 때마다 예약 정보 새로고침
   useEffect(() => {
     if (isOpen && userId) {
-      refetchReservations();
+      refetchReservations()
     }
-  }, [isOpen, userId, refetchReservations]);
+  }, [isOpen, userId, refetchReservations])
 
   // 정렬된 예약 목록
   const sortedReservations = useMemo(() => {
-    return [...reservations].sort(
-      (a, b) => a.date.getTime() - b.date.getTime()
-    );
-  }, [reservations]);
+    return [...reservations].sort((a, b) => a.date.getTime() - b.date.getTime())
+  }, [reservations])
 
   // 게임별 예약 횟수를 계산하는 함수
   const gameReservationCounts = useMemo(() => {
-    const countMap: Record<string, { count: number; game: any }> = {};
+    const countMap: Record<string, { count: number; game: any }> = {}
 
     reservations.forEach((reservation) => {
-      if (!reservation.game) return;
+      if (!reservation.game) return
 
-      const gameId = reservation.game.id;
+      const gameId = reservation.game.id
       if (!countMap[gameId]) {
         countMap[gameId] = {
           count: 0,
           game: reservation.game,
-        };
+        }
       }
-      countMap[gameId].count += 1;
-    });
+      countMap[gameId].count += 1
+    })
 
-    return Object.values(countMap);
-  }, [reservations]);
+    return Object.values(countMap)
+  }, [reservations])
 
   // 게임별 토큰 계산
   const totalTokens = useMemo(() => {
-    return reservations.length * 700;
-  }, [reservations]);
+    return reservations.length * 700
+  }, [reservations])
 
   // 특정 시간이 예약 가능한지 확인하는 함수
   const isTimeAvailable = useCallback(
     (time: Date) => {
-      const currentTime = new Date();
+      const currentTime = new Date()
 
       // 1. 현재 시간 이전인지 확인
       if (!isAfter(time, currentTime)) {
-        return false;
+        return false
       }
 
       // 2. 이미 사용자가 추가한 예약 시간과 겹치는지 확인
       const isReservedByUser = reservations.some(
         (res) =>
-          isSameDay(time, res.date) &&
-          isSameHour(time, res.date) &&
-          isSameMinute(time, res.date)
-      );
+          isSameDay(time, res.date) && isSameHour(time, res.date) && isSameMinute(time, res.date),
+      )
 
       // 3. 기존 예약 시간과 겹치는지 확인
       const isAlreadyReserved = existingReservations.some(
         (reservedTime: Date) =>
           isSameDay(time, reservedTime) &&
           isSameHour(time, reservedTime) &&
-          isSameMinute(time, reservedTime)
-      );
+          isSameMinute(time, reservedTime),
+      )
 
-      return !isReservedByUser && !isAlreadyReserved;
+      return !isReservedByUser && !isAlreadyReserved
     },
-    [reservations, existingReservations]
-  );
+    [reservations, existingReservations],
+  )
 
   // 시간 간격 생성 (30분 간격)
   const getAvailableTimes = useCallback(
     (date: Date) => {
-      if (!date) return [];
+      if (!date) return []
 
-      const times = [];
-      const startTime = new Date(date);
-      startTime.setHours(0, 0, 0, 0);
+      const times = []
+      const startTime = new Date(date)
+      startTime.setHours(0, 0, 0, 0)
 
       for (let i = 0; i < 48; i++) {
         // 30분 간격으로 48개 시간 (24시간)
-        const time = new Date(startTime.getTime() + i * 30 * 60 * 1000);
+        const time = new Date(startTime.getTime() + i * 30 * 60 * 1000)
         if (isTimeAvailable(time)) {
-          times.push(time);
+          times.push(time)
         }
       }
 
-      return times;
+      return times
     },
-    [isTimeAvailable]
-  );
+    [isTimeAvailable],
+  )
 
   // 날짜가 변경될 때 사용 가능한 시간 업데이트
   useEffect(() => {
     if (selectedDate) {
-      const dateOnly = new Date(selectedDate);
-      dateOnly.setHours(0, 0, 0, 0);
-      const times = getAvailableTimes(dateOnly);
-      setAvailableTimes(times);
+      const dateOnly = new Date(selectedDate)
+      dateOnly.setHours(0, 0, 0, 0)
+      const times = getAvailableTimes(dateOnly)
+      setAvailableTimes(times)
     } else {
-      setAvailableTimes([]);
+      setAvailableTimes([])
     }
-  }, [selectedDate, getAvailableTimes]);
+  }, [selectedDate, getAvailableTimes])
 
   // 예약 추가 - 시간과 게임이 있어야 가능 (useCallback 추가)
   const handleAddReservation = useCallback(() => {
-    if (!selectedTime || !selectedGame) return;
+    if (!selectedTime || !selectedGame) return
 
     // 예약에 추가할 전체 일시 생성 (선택된 날짜 + 선택된 시간)
-    const reservationDateTime = new Date(selectedTime);
-    
+    const reservationDateTime = new Date(selectedTime)
+
     setReservations((prev) => {
       if (prev.length >= 5) {
-        alert("한 번에 최대 5개까지만 예약할 수 있습니다.");
-        return prev;
+        alert("한 번에 최대 5개까지만 예약할 수 있습니다.")
+        return prev
       }
 
       const newReservations = [
@@ -204,30 +233,30 @@ export default function ReservationModal({
           date: reservationDateTime,
           game: selectedGame,
         },
-      ];
-      return newReservations;
-    });
-    
+      ]
+      return newReservations
+    })
+
     // 시간만 초기화하고 날짜는 유지
-    setSelectedTime(null);
-  }, [selectedTime, selectedGame]);
+    setSelectedTime(null)
+  }, [selectedTime, selectedGame])
 
   // 예약 제거 (useCallback 추가)
   const handleRemoveReservation = useCallback((id: number) => {
-    setReservations(prev => prev.filter((res) => res.id !== id));
-  }, []);
+    setReservations((prev) => prev.filter((res) => res.id !== id))
+  }, [])
 
   // 결제 단계로 이동 (useCallback 추가)
   const handleSubmit = useCallback(() => {
-    if (!selectedGame || reservations.length === 0) return;
+    if (!selectedGame || reservations.length === 0) return
     // 선택 단계에서 결제 단계로 이동
-    setPhase("payment");
-  }, [selectedGame, reservations.length]);
+    setPhase("payment")
+  }, [selectedGame, reservations.length])
 
   // 결제 단계에서 이전 단계로 돌아가기 (useCallback 추가)
   const handleBack = useCallback(() => {
-    setPhase("select");
-  }, []);
+    setPhase("select")
+  }, [])
 
   // 결제 처리에 useMutation 사용
   const createOrderMutation = useMutation<
@@ -245,58 +274,69 @@ export default function ReservationModal({
           scheduledDate: reservation.date.toISOString().split("T")[0], // YYYY-MM-DD 형식
           scheduledTime: reservation.date.toTimeString().split(" ")[0], // HH:MM:SS 형식
           price: 700, // 게임당 고정 가격
-        };
+        }
 
         // orderApi를 통해 의뢰 생성
-        return await orderApi.createOrder(orderData);
-      });
+        return await orderApi.createOrder(orderData)
+      })
 
       // 모든 의뢰 생성 요청 처리 대기
-      return await Promise.all(createOrderPromises);
+      return await Promise.all(createOrderPromises)
     },
     onSuccess: () => {
-      alert("결제가 완료되었습니다. 예약이 확정되었습니다.");
+      alert("결제가 완료되었습니다. 예약이 확정되었습니다.")
 
       // 상태 초기화 및 모달 닫기
-      setPhase("select");
-      setReservations([]);
-      setSelectedGame(null);
-      onClose();
+      setPhase("select")
+      setReservations([])
+      setSelectedGame(null)
+      onClose()
 
       // 예약 정보 새로고침
-      refetchReservations();
+      refetchReservations()
     },
     onError: (error) => {
-      console.error("결제 처리 오류:", error);
+      console.error("결제 처리 오류:", error)
       alert(
         `결제 처리 중 오류가 발생했습니다: ${
           error instanceof Error ? error.message : "알 수 없는 오류"
-        }`
-      );
+        }`,
+      )
     },
-  });
+  })
 
   // 최종 결제 처리 (useCallback 추가)
   const handlePayment = useCallback(() => {
-    if (!selectedGame || reservations.length === 0) return;
-    createOrderMutation.mutate();
-  }, [selectedGame, reservations.length, createOrderMutation]);
+    if (!selectedGame || reservations.length === 0) return
+    createOrderMutation.mutate()
+  }, [selectedGame, reservations.length, createOrderMutation])
 
   // 로딩 상태 및 버튼 disabled 조건 최적화 (useMemo 추가)
-  const isLoading = useMemo(() => 
-    isLoadingReservations || createOrderMutation.isPending || isSubmitting,
-    [isLoadingReservations, createOrderMutation.isPending, isSubmitting]
-  );
+  const isLoading = useMemo(
+    () =>
+      isLoadingReservations ||
+      createOrderMutation.isPending ||
+      isSubmitting ||
+      isLoadingSelectedGames ||
+      isLoadingTitles,
+    [
+      isLoadingReservations,
+      createOrderMutation.isPending,
+      isSubmitting,
+      isLoadingSelectedGames,
+      isLoadingTitles,
+    ],
+  )
 
-  const hasError = useMemo(() => reservationError !== null, [reservationError]);
-  
+  const hasError = useMemo(() => reservationError !== null, [reservationError])
+
   // 결제 버튼 비활성화 조건 메모이제이션
-  const isPaymentDisabled = useMemo(() => 
-    !selectedGame || reservations.length === 0 || isLoading,
-    [selectedGame, reservations.length, isLoading]
-  );
+  const isPaymentDisabled = useMemo(
+    () => !selectedGame || reservations.length === 0 || isLoading,
+    [selectedGame, reservations.length, isLoading],
+  )
 
-  if (!isOpen) return null;
+  if (!isOpen) return null
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
@@ -309,9 +349,7 @@ export default function ReservationModal({
           <X className="w-4 h-4" />
         </button>
 
-        <h3 className="text-xl font-bold mb-6">
-          {phase === "select" ? "예약하기" : "결제하기"}
-        </h3>
+        <h3 className="text-xl font-bold mb-6">{phase === "select" ? "예약하기" : "결제하기"}</h3>
 
         {hasError && (
           <div className="alert alert-error mb-4">
@@ -335,9 +373,7 @@ export default function ReservationModal({
 
             {/* 예약 목록 */}
             <div className="mt-4">
-              <h3 className="font-bold mb-2">
-                예약 목록 ({reservations.length}/5)
-              </h3>
+              <h3 className="font-bold mb-2">예약 목록 ({reservations.length}/5)</h3>
               <ReservationList
                 reservations={sortedReservations}
                 formatDate={formatDate}
@@ -346,9 +382,9 @@ export default function ReservationModal({
               />
             </div>
 
-            {/* 게임 선택 영역 */}
+            {/* 게임 선택 영역 (메이트가 제공 가능한 게임만) */}
             <GameSelector
-              games={games}
+              games={mappedProviderGames}
               selectedGame={selectedGame}
               setSelectedGame={setSelectedGame}
               isLoading={isLoading}
@@ -360,13 +396,9 @@ export default function ReservationModal({
                 gameReservationCounts={gameReservationCounts}
                 totalTokens={totalTokens}
               />
-              
+
               <div className="flex gap-2">
-                <button
-                  className="btn btn-ghost"
-                  onClick={onClose}
-                  disabled={isLoading}
-                >
+                <button className="btn btn-ghost" onClick={onClose} disabled={isLoading}>
                   취소
                 </button>
                 <button
@@ -392,7 +424,7 @@ export default function ReservationModal({
               formatDate={formatDate}
               totalTokens={totalTokens}
             />
-            
+
             <div className="flex justify-between gap-4 mt-6">
               <button
                 className="btn btn-outline flex-1"
@@ -417,5 +449,5 @@ export default function ReservationModal({
         )}
       </div>
     </div>
-  );
+  )
 }

--- a/app/profile/_components/ProfileGameList.tsx
+++ b/app/profile/_components/ProfileGameList.tsx
@@ -55,19 +55,20 @@ export default function ProfileGameList({
   const defaultRating = 0 // GameCard에서 필요한 기본값
   const defaultReviewCount = 0 // GameCard에서 필요한 기본값
 
+  // 대표 게임: 첫 번째 항목
+  const representative = userGames[0]
+
   return (
     <>
       {/* 로딩 동안에도 Skeleton 없이 즉시 렌더링하며, 이미지/가격 등은 기본값 처리 */}
-      {userGames.map((game) => (
-        <GameCard
-          key={game.id}
-          game={game}
-          rating={rating ?? defaultRating} // 전달받은 값 또는 기본값 사용
-          reviewCount={reviewCount ?? defaultReviewCount} // 전달받은 값 또는 기본값 사용
-          isOwner={isOwner}
-          providerUserId={providerUserId}
-        />
-      ))}
+      <GameCard
+        key={representative.id}
+        game={representative}
+        rating={rating ?? defaultRating}
+        reviewCount={reviewCount ?? defaultReviewCount}
+        isOwner={isOwner}
+        providerUserId={providerUserId}
+      />
     </>
   )
 }

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -59,6 +59,7 @@ export const queryKeys = {
     albumImagesPublic: (publicUserId: string | number) =>
       ["albumImagesPublic", String(publicUserId)] as const,
     publicById: (publicId: number) => ["profilePublic", publicId] as const,
+    selectedGamesByUserId: (userId: string) => ["profile", "selectedGames", userId] as const,
   },
 } as const
 
@@ -90,6 +91,7 @@ export type QueryKey = ReturnType<
   | typeof queryKeys.profile.albumImages
   | typeof queryKeys.profile.albumImagesPublic
   | typeof queryKeys.profile.publicById
+  | typeof queryKeys.profile.selectedGamesByUserId
 >
 
 // Legacy compat single keys (kept to avoid breaking existing hooks)

--- a/hooks/api/profile/useSelectedGamesByUserId.ts
+++ b/hooks/api/profile/useSelectedGamesByUserId.ts
@@ -1,0 +1,34 @@
+"use client"
+
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query"
+
+import { queryKeys } from "@/constants/queryKeys"
+import { fetchJson } from "@/libs/api/fetchJson"
+
+export interface SelectedGamesResponse {
+  selectedGames: string[]
+}
+
+export function useSelectedGamesByUserId(
+  userId: string | undefined,
+  options?: UseQueryOptions<
+    SelectedGamesResponse,
+    Error,
+    SelectedGamesResponse,
+    ReturnType<typeof queryKeys.profile.selectedGamesByUserId>
+  >,
+) {
+  return useQuery({
+    queryKey: userId
+      ? queryKeys.profile.selectedGamesByUserId(userId)
+      : (["profile", "selectedGames", "unknown"] as const),
+    queryFn: async () =>
+      fetchJson<SelectedGamesResponse>(
+        `/api/profile/selected-games?userId=${encodeURIComponent(userId!)}`,
+      ),
+    enabled: !!userId,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    ...options,
+  })
+}

--- a/hooks/useProfileForm.ts
+++ b/hooks/useProfileForm.ts
@@ -1,30 +1,34 @@
-import { useEffect, useCallback } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import { useForm, UseFormReturn, SubmitHandler } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { toast } from 'react-hot-toast';
-import isEqual from 'lodash/isEqual';
-import { ZodError } from 'zod';
+import { useEffect, useCallback } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { useForm, type UseFormReturn, type SubmitHandler } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "react-hot-toast"
+import isEqual from "lodash/isEqual"
+import { ZodError } from "zod"
 
-import { profileSchema, ProfileDataSchema } from '@/libs/schemas/profile.schema';
-import { useProfileInfoQuery } from '@/hooks/api/profile/useProfileQueries';
-import { useUpdateProfileMutation } from '@/hooks/api/profile/useProfileMutations';
-import { queryKeys } from '@/constants/queryKeys';
-import { parseApiError, setFormErrors } from '@/utils/errors/errorUtils';
+import {
+  profileSchema,
+  profilePartialSchema,
+  type ProfileDataSchema,
+} from "@/libs/schemas/profile.schema"
+import { useProfileInfoQuery } from "@/hooks/api/profile/useProfileQueries"
+import { useUpdateProfileMutation } from "@/hooks/api/profile/useProfileMutations"
+import { queryKeys } from "@/constants/queryKeys"
+import { parseApiError, setFormErrors } from "@/utils/errors/errorUtils"
 
 // Custom hook return type
 interface UseProfileFormReturn {
-  methods: UseFormReturn<ProfileDataSchema>; // RHF methods and state
-  onSubmit: SubmitHandler<ProfileDataSchema>; // Form submission handler
-  isLoadingProfile: boolean;
-  isSaving: boolean;
-  isError: boolean;
-  profileQueryError: Error | null;
-  handleCancel: () => void; // Cancel handler
+  methods: UseFormReturn<ProfileDataSchema> // RHF methods and state
+  onSubmit: SubmitHandler<ProfileDataSchema> // Form submission handler
+  isLoadingProfile: boolean
+  isSaving: boolean
+  isError: boolean
+  profileQueryError: Error | null
+  handleCancel: () => void // Cancel handler
 }
 
 export function useProfileForm(): UseProfileFormReturn {
-  const queryClient = useQueryClient();
+  const queryClient = useQueryClient()
 
   // --- Data Fetching ---
   const {
@@ -32,105 +36,116 @@ export function useProfileForm(): UseProfileFormReturn {
     isLoading: isLoadingProfile,
     isError,
     error: profileQueryError,
-    refetch: refetchProfileInfo // Add refetch function
-  } = useProfileInfoQuery();
+    refetch: refetchProfileInfo, // Add refetch function
+  } = useProfileInfoQuery()
 
   // --- Form Initialization ---
   const methods = useForm<ProfileDataSchema>({
     resolver: zodResolver(profileSchema),
-    mode: 'onChange',
-    defaultValues: { // Keep defaults simple, reset logic handles API data
-      nickname: '',
-      username: '',
-      description: '',
+    mode: "onChange",
+    defaultValues: {
+      // Keep defaults simple, reset logic handles API data
+      nickname: "",
+      username: "",
+      description: "",
       selected_games: [],
       youtube_urls: [],
       is_mate: false,
       selected_tags: [],
-    }
-  });
-  const { reset, setError, formState: { defaultValues, isDirty } } = methods;
-
+    },
+  })
+  const {
+    reset,
+    setError,
+    formState: { defaultValues, isDirty },
+  } = methods
 
   // --- Effect for Resetting Form with Fetched Data ---
   useEffect(() => {
     // Only reset if profileData is successfully fetched
     if (profileData) {
-      const validatedData = profileSchema.partial().safeParse(profileData);
+      const validatedData = profilePartialSchema.safeParse(profileData)
+
       if (validatedData.success) {
         // Reset with validated data merged with defaults to ensure all fields exist
-         const dataToReset = {
-           // Directly use methods.formState.defaultValues here if needed,
-           // but it's not a dependency for the effect trigger itself.
-           ...methods.formState.defaultValues,
-           ...validatedData.data,
-         };
-        reset(dataToReset);
+        const dataToReset = {
+          // Directly use methods.formState.defaultValues here if needed,
+          // but it's not a dependency for the effect trigger itself.
+          ...methods.formState.defaultValues,
+          ...validatedData.data,
+        }
+        reset(dataToReset)
       } else {
-        console.error("Fetched profile data doesn't match schema in hook:", validatedData.error);
-         // Use the stable reset function with stable defaultValues reference
-         reset(methods.formState.defaultValues);
+        console.error("Fetched profile data doesn't match schema in hook:", validatedData.error)
+        // Use the stable reset function with stable defaultValues reference
+        reset(methods.formState.defaultValues)
       }
     } else if (!isLoadingProfile && !isError) {
-        // If not loading and no error, but profileData is null, reset to defaults
-        // Use the stable reset function with stable defaultValues reference
-        reset(methods.formState.defaultValues);
+      // If not loading and no error, but profileData is null, reset to defaults
+      // Use the stable reset function with stable defaultValues reference
+      reset(methods.formState.defaultValues)
     }
     // Dependencies: profileData (query result), reset function reference, loading/error states
     // defaultValues reference from RHF is stable
-  }, [profileData, reset, isLoadingProfile, isError]); // Removed defaultValues
+  }, [profileData, reset, isLoadingProfile, isError]) // Removed defaultValues
 
   // --- Data Mutation ---
   const { mutate: updateProfile, isPending: isSaving } = useUpdateProfileMutation({
     onSuccess: () => {
-      toast.success('프로필이 성공적으로 저장되었습니다');
+      toast.success("프로필이 성공적으로 저장되었습니다")
       // 캐시 무효화는 mutation 내부에서 처리됨
       // 폼 리셋은 useEffect에서 새로운 profileData로 자동 처리
     },
     onError: (error: any) => {
-      const parsed = parseApiError(error);
-      setFormErrors(setError, parsed.fieldErrors);
-      toast.error(parsed.generalMessage);
-    }
-  });
+      const parsed = parseApiError(error)
+      setFormErrors(setError, parsed.fieldErrors)
+      toast.error(parsed.generalMessage)
+    },
+  })
 
   // --- Form Submission Handler ---
   // Use useCallback to memoize the onSubmit function
-  const onSubmit: SubmitHandler<ProfileDataSchema> = useCallback((data) => {
-    const changedData: Partial<ProfileDataSchema> = {};
-    // Get current profile data from cache for comparison
-    const currentProfileData = queryClient.getQueryData<ProfileDataSchema | null>(queryKeys.profile.info());
+  const onSubmit: SubmitHandler<ProfileDataSchema> = useCallback(
+    (data) => {
+      const changedData: Partial<ProfileDataSchema> = {}
+      // Get current profile data from cache for comparison
+      const currentProfileData = queryClient.getQueryData<ProfileDataSchema | null>(
+        queryKeys.profile.info(),
+      )
 
-    if (currentProfileData) {
-      (Object.keys(data) as Array<keyof ProfileDataSchema>).forEach(key => {
-        if (!isEqual(data[key], currentProfileData[key])) {
-          (changedData as any)[key] = data[key];
-        }
-      });
-    }
+      if (currentProfileData) {
+        ;(Object.keys(data) as Array<keyof ProfileDataSchema>).forEach((key) => {
+          if (!isEqual(data[key], currentProfileData[key])) {
+            ;(changedData as any)[key] = data[key]
+          }
+        })
+      }
 
-    // Check if there are actual changes before submitting
-    if (Object.keys(changedData).length > 0) {
-       // TODO: Add necessary identifiers like ID if API requires for PATCH
-       // if(currentProfileData?.id) { changedData.id = currentProfileData.id }
-      updateProfile(changedData);
-    } else if (isDirty) {
+      // Check if there are actual changes before submitting
+      if (Object.keys(changedData).length > 0) {
+        // TODO: Add necessary identifiers like ID if API requires for PATCH
+        // if(currentProfileData?.id) { changedData.id = currentProfileData.id }
+        updateProfile(changedData)
+      } else if (isDirty) {
         // If the form is dirty but no deep changes detected (e.g., array manipulation back to original)
-        toast('변경된 내용이 없습니다.');
+        toast("변경된 내용이 없습니다.")
         // Optionally reset to remove dirty state if isEqual is reliable
-         reset(currentProfileData ?? defaultValues);
-    } else {
-         toast('변경된 내용이 없습니다.');
-    }
-    // If API requires full update: updateProfile(data);
-  }, [queryClient, updateProfile, isDirty, reset, defaultValues]); // Dependencies for onSubmit
+        reset(currentProfileData ?? defaultValues)
+      } else {
+        toast("변경된 내용이 없습니다.")
+      }
+      // If API requires full update: updateProfile(data);
+    },
+    [queryClient, updateProfile, isDirty, reset, defaultValues],
+  ) // Dependencies for onSubmit
 
   // --- Cancel Handler ---
   const handleCancel = useCallback(() => {
-      const currentProfileData = queryClient.getQueryData<ProfileDataSchema | null>(queryKeys.profile.info());
-      reset(currentProfileData ?? defaultValues); // Reset to cached data or defaults
-  }, [queryClient, reset, defaultValues]);
-
+    const currentProfileData = queryClient.getQueryData<ProfileDataSchema | null>(
+      queryKeys.profile.info(),
+    )
+    reset(currentProfileData ?? defaultValues) // Reset to cached data or defaults
+  }, [queryClient, reset, defaultValues])
 
   // --- Return Values ---
   return {
@@ -141,5 +156,5 @@ export function useProfileForm(): UseProfileFormReturn {
     isError,
     profileQueryError,
     handleCancel,
-  };
-} 
+  }
+}

--- a/libs/schemas/profile.schema.ts
+++ b/libs/schemas/profile.schema.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import { z } from "zod"
 
-// 프로필 데이터 유효성 검사를 위한 Zod 스키마 정의
-export const profileSchema = z.object({
+// 프로필 데이터 유효성 검사를 위한 Zod 스키마 정의 (객체 스키마 분리)
+const profileSchemaObject = z.object({
   // 식별자 필드 (업데이트 시 필요 없을 수 있으므로 optional 추가 고려)
   // id: z.string().uuid().optional(),
   // user_id: z.string().uuid().optional(),
@@ -12,53 +12,63 @@ export const profileSchema = z.object({
   // updated_at: z.string().datetime().nullable().optional(),
 
   // --- 사용자가 수정 가능한 필드에 유효성 검사 규칙 추가 ---
-  nickname: z.string({
+  nickname: z
+    .string({
       required_error: "닉네임은 필수 항목입니다.", // Zod 3.x 이상에서는 required_error 사용 가능
       invalid_type_error: "닉네임은 문자열이어야 합니다.",
     })
-    .min(1, { message: '닉네임은 비워둘 수 없습니다.' })
-    .max(50, { message: '닉네임은 50자를 초과할 수 없습니다.' })
+    .min(1, { message: "닉네임은 비워둘 수 없습니다." })
+    .max(50, { message: "닉네임은 50자를 초과할 수 없습니다." })
     .nullable(), // DB 스키마에 따라 null 허용 여부 결정
 
   // --- username 필드 추가 (프로필 태그명) ---
-  username: z.string({
+  username: z
+    .string({
       required_error: "태그명(사용자 이름)은 필수 항목입니다.",
       invalid_type_error: "태그명(사용자 이름)은 문자열이어야 합니다.",
     })
-    .min(3, { message: '태그명(사용자 이름)은 3자 이상이어야 합니다.' })
-    .max(30, { message: '태그명(사용자 이름)은 30자를 초과할 수 없습니다.' })
+    .min(3, { message: "태그명(사용자 이름)은 3자 이상이어야 합니다." })
+    .max(30, { message: "태그명(사용자 이름)은 30자를 초과할 수 없습니다." })
     // 필요시 정규식 추가 (예: 영문, 숫자, 밑줄만 허용)
     // .regex(/^[a-zA-Z0-9_]+$/, { message: '태그명(사용자 이름)은 영문, 숫자, 밑줄(_)만 사용할 수 있습니다.' })
     .nullable(), // DB 스키마에 따라 null 허용 여부 결정
 
   // DB 컬럼명이 'description'이라면 스키마 필드명도 일치시키는 것이 좋음
-  description: z.string({
+  description: z
+    .string({
       invalid_type_error: "소개는 문자열이어야 합니다.",
     })
-    .max(1000, { message: '소개는 1000자를 초과할 수 없습니다.' })
+    .max(1000, { message: "소개는 1000자를 초과할 수 없습니다." })
     .nullable(),
 
-  selected_games: z.array(z.string(), {
+  selected_games: z
+    .array(z.string(), {
       invalid_type_error: "선택된 게임은 문자열 배열이어야 합니다.",
     })
-    .max(10, { message: '게임은 최대 10개까지 선택할 수 있습니다.' })
+    .max(10, { message: "게임은 최대 10개까지 선택할 수 있습니다." })
     .nullable(),
 
-  selected_tags: z.array(z.string(), {
+  selected_tags: z
+    .array(z.string(), {
       invalid_type_error: "선택된 태그는 문자열 배열이어야 합니다.",
     })
-    .max(15, { message: '태그는 최대 15개까지 선택할 수 있습니다.' })
+    .max(15, { message: "태그는 최대 15개까지 선택할 수 있습니다." })
     .nullable(),
 
-  youtube_urls: z.array(
-      z.string({ invalid_type_error: "YouTube URL은 문자열이어야 합니다." })
-       .url({ message: '유효한 URL 형식이 아닙니다.' })
-       // 필요시 정규식 강화: .regex(/^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.?be)\/.+$/, { message: "유효한 YouTube URL 형식이 아닙니다." })
-    , { invalid_type_error: "YouTube URL 목록은 배열이어야 합니다."})
-    .max(5, { message: 'YouTube 영상은 최대 5개까지 등록할 수 있습니다.' })
+  youtube_urls: z
+    .array(
+      z
+        .string({ invalid_type_error: "YouTube URL은 문자열이어야 합니다." })
+        .url({ message: "유효한 URL 형식이 아닙니다." }),
+      // 필요시 정규식 강화: .regex(/^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.?be)\/.+$/, { message: "유효한 YouTube URL 형식이 아닙니다." })
+      { invalid_type_error: "YouTube URL 목록은 배열이어야 합니다." },
+    )
+    .max(5, { message: "YouTube 영상은 최대 5개까지 등록할 수 있습니다." })
     .nullable(),
 
-  is_mate: z.boolean({ invalid_type_error: "메이트 등록 여부는 boolean 값이어야 합니다."}).nullable(),
+  is_mate: z
+    .boolean({ invalid_type_error: "메이트 등록 여부는 boolean 값이어야 합니다." })
+    .nullable(),
 
   // --- 다른 필요한 필드 (DB 스키마 기준, 읽기 전용이라도 타입 정의 목적) ---
   // follower_count: z.number().int().nonnegative().nullable().optional(),
@@ -66,10 +76,28 @@ export const profileSchema = z.object({
   // username: z.string().nullable().optional(),
   // id, user_id, public_id, created_at, updated_at 등 DB에는 있지만
   // 업데이트 시 사용자가 직접 보내지 않는 값들은 스키마에서 제외하거나 optional 처리 가능
-});
+})
 
-// Zod 스키마로부터 TypeScript 타입 추론
-export type ProfileDataSchema = z.infer<typeof profileSchema>;
+// 교차 필드 검증: is_mate=true이면 선택 게임이 최소 1개 이상이어야 함
+export const profileSchema = profileSchemaObject.superRefine((data, ctx) => {
+  // 교차 필드 검증: is_mate=true이면 선택 게임이 최소 1개 이상이어야 함
+  if (data?.is_mate === true) {
+    const count = Array.isArray(data?.selected_games) ? data.selected_games.length : 0
+    if (count < 1) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["selected_games"],
+        message: "메이트로 등록하려면 최소 1개 이상의 게임을 선택해야 합니다.",
+      })
+    }
+  }
+})
+
+// 부분 업데이트에 사용할 Partial 스키마
+export const profilePartialSchema = profileSchemaObject.partial()
+
+// Zod 스키마로부터 TypeScript 타입 추론 (객체 스키마 기준)
+export type ProfileDataSchema = z.infer<typeof profileSchemaObject>
 
 // 참고: 위 스키마는 주로 '업데이트' 시나리오에 맞춰 작성되었습니다.
 // '생성' 시나리오나 다른 용도로 사용될 경우, 필드의 필수 여부(nullable, optional 제거 등)를 조정해야 할 수 있습니다.

--- a/libs/schemas/server/profile.schema.ts
+++ b/libs/schemas/server/profile.schema.ts
@@ -1,17 +1,26 @@
-import { z } from 'zod'
+import { z } from "zod"
 
 // GET /api/profile/public?publicId=...
 export const profilePublicGetQuerySchema = z.object({
   publicId: z.coerce
-    .number({ invalid_type_error: 'publicId는 숫자여야 합니다.' })
-    .int({ message: 'publicId는 정수여야 합니다.' })
-    .positive({ message: 'publicId는 1 이상의 값이어야 합니다.' })
+    .number({ invalid_type_error: "publicId는 숫자여야 합니다." })
+    .int({ message: "publicId는 정수여야 합니다." })
+    .positive({ message: "publicId는 1 이상의 값이어야 합니다." }),
 })
 
 export type ProfilePublicGetQuery = z.infer<typeof profilePublicGetQuerySchema>
- 
- export const profileImageUpdateBodySchema = z.object({
-   imageUrl: z
-     .string({ required_error: 'imageUrl은 필수입니다.' })
-     .min(1, { message: 'imageUrl는 비어 있을 수 없습니다.' })
- })
+
+export const profileImageUpdateBodySchema = z.object({
+  imageUrl: z
+    .string({ required_error: "imageUrl은 필수입니다." })
+    .min(1, { message: "imageUrl는 비어 있을 수 없습니다." }),
+})
+
+// GET /api/profile/selected-games?userId=...
+export const profileSelectedGamesGetQuerySchema = z.object({
+  userId: z
+    .string({ required_error: "userId는 필수입니다." })
+    .uuid({ message: "userId는 UUID 형식이어야 합니다." }),
+})
+
+export type ProfileSelectedGamesGetQuery = z.infer<typeof profileSelectedGamesGetQuerySchema>


### PR DESCRIPTION
Why
- 예약 흐름과 프로필 데이터 간 정합성 강화
- is_mate=true일 때 최소 1개 게임 필요(시스템 의미 일관성)

What
- 클라 Zod(superRefine) + 서버 병합 검증 추가
- GET /api/profile/selected-games 신설(+ Zod 검증)
- ReservationModal 하드코딩 제거 → selected_games + useGamesByTitles
- ProfileGameList 대표 게임 1개만 렌더
- queryKeys.profile.selectedGamesByUserId 추가

 How
- profile.schema.ts: object-level superRefine
- infoService.ts: DB 병합 후 조건 검사(400 + details)
- reservation modal: selected_games fetch → useGamesByTitles 매핑
- 대표 게임: 첫 번째 항목 사용
- 
 Test Plan
1) is_mate=true + selected_games=[] 저장 시 → 클라/서버 에러 확인
2) 예약 모달 게임 목록이 메이트 제공 게임과 일치
3) 프로필에서 대표 게임 1개만 노출
4) 로딩/에러 UI 확인
