### PR TITLE
[feat] : SideBar.tsx 전역 상태 사용으로 모바일 뷰 on/off제어, 사용자 편의성 개선

### DIFF
--- a/app/dashboard/_components/Header.tsx
+++ b/app/dashboard/_components/Header.tsx
@@ -1,14 +1,11 @@
-"use client";
-
-import HeaderLeft from "./header/HeaderLeft";
-import HeaderRight from "./header/HeaderRight";
-
+import HeaderLeft from "./header/HeaderLeft"
+import HeaderRight from "./header/HeaderRight"
 
 export default function Header() {
   return (
-      <div className="sticky top-0 z-50 flex items-center justify-between gap-4 h-14 px-2 border-b border-gray-300 bg-base-100">
-        <HeaderLeft />
-        <HeaderRight />
-      </div>
-  );
+    <div className="sticky top-0 z-50 flex items-center justify-between gap-4 h-14 px-2 border-b border-gray-300 bg-base-100">
+      <HeaderLeft />
+      <HeaderRight />
+    </div>
+  )
 }

--- a/app/dashboard/_components/header/HeaderLeft.tsx
+++ b/app/dashboard/_components/header/HeaderLeft.tsx
@@ -1,30 +1,34 @@
-"use client";
+"use client"
 
-import { useRouter } from "next/navigation";
-import Image from "next/image";
+import { useRouter } from "next/navigation"
+import Image from "next/image"
+import { Menu } from "lucide-react"
+
+import { useSidebarStore } from "@/stores/sidebarStore"
 
 export default function HeaderLeft() {
-  const router = useRouter();
+  const router = useRouter()
+  const { toggle, isOpen } = useSidebarStore()
 
   const handleLogoClick = () => {
-    router.push('/');
-  };
-
-  const handleIntroClick = () => {
-    router.push('/intro');
-  };
-
-  const handleCategoryClick = () => {
-    router.push('/category');
-  };
+    router.push("/")
+  }
 
   return (
     <div className="flex items-center gap-4 pl-6 md:pl-0">
+      {/* 모바일 전용 햄버거 버튼: 사이드바 토글 */}
+      <button
+        type="button"
+        className="md:hidden btn btn-ghost btn-sm flex items-center h-[40px]"
+        aria-controls="app-sidebar"
+        aria-expanded={isOpen}
+        onClick={toggle}
+      >
+        <Menu className="w-5 h-5" />
+      </button>
       <div className="cursor-pointer group" onClick={handleLogoClick}>
         <Image src="/icons/free-icon-gamepad.png" alt="logo" width={30} height={30} />
       </div>
-      <button className="cursor-pointer hover:text-gray-300" onClick={handleCategoryClick}>카테고리</button>
-      <button className="cursor-pointer hover:text-gray-300" onClick={handleIntroClick}>소개</button>
     </div>
-  );
-} 
+  )
+}

--- a/hooks/ui/useBodyScrollLock.ts
+++ b/hooks/ui/useBodyScrollLock.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from "react"
+
+// 모바일 전용 body 스크롤 락 훅
+// - 루트 레이아웃/서버 컴포넌트는 변경하지 않고, 클라이언트 컴포넌트 내부에서만 사용
+// - enabled=true일 때만 잠금, 언마운트/의존성 변경 시 해제
+// - 여러 컴포넌트에서 중복 사용될 경우를 대비해 레퍼런스 카운트로 안전하게 처리
+
+export type BodyScrollLockOptions = {
+  // 모바일에서만 적용할지 여부 (기본값: true)
+  onlyMobile?: boolean
+  // 모바일 기준 max-width(px). Tailwind md 기준: 768px -> max-width: 767px
+  breakpoint?: number
+}
+
+let lockCount = 0
+let savedScrollY = 0
+
+export function useBodyScrollLock(enabled: boolean, options: BodyScrollLockOptions = {}) {
+  const { onlyMobile = true, breakpoint = 767 } = options
+  const activeRef = useRef(false)
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") return
+
+    const isMobile = window.matchMedia(`(max-width: ${breakpoint}px)`).matches
+
+    // 잠금 조건 불충족 시 해제
+    if (!enabled || (onlyMobile && !isMobile)) {
+      if (activeRef.current) {
+        unlock()
+        activeRef.current = false
+      }
+      return
+    }
+
+    // 잠금
+    lock()
+    activeRef.current = true
+
+    // 클린업
+    return () => {
+      if (activeRef.current) {
+        unlock()
+        activeRef.current = false
+      }
+    }
+  }, [enabled, onlyMobile, breakpoint])
+}
+
+function lock() {
+  if (lockCount === 0) {
+    savedScrollY = window.scrollY || window.pageYOffset
+    const body = document.body
+    body.style.position = "fixed"
+    body.style.top = `-${savedScrollY}px`
+    body.style.left = "0"
+    body.style.right = "0"
+    body.style.width = "100%"
+    body.style.overflow = "hidden"
+    // 모바일 Safari 등에서 바운스/제스처 방지 보조 속성 (타입 안전하게 setProperty 사용)
+    body.style.setProperty("touch-action", "none")
+    body.style.setProperty("overscroll-behavior", "none")
+  }
+  lockCount += 1
+}
+
+function unlock() {
+  lockCount = Math.max(0, lockCount - 1)
+  if (lockCount === 0) {
+    const body = document.body
+    const top = body.style.top
+    body.style.position = ""
+    body.style.top = ""
+    body.style.left = ""
+    body.style.right = ""
+    body.style.width = ""
+    body.style.overflow = ""
+    body.style.setProperty("touch-action", "")
+    body.style.setProperty("overscroll-behavior", "")
+
+    const scrollY = top ? -parseInt(top, 10) : 0
+    window.scrollTo(0, scrollY)
+  }
+}

--- a/stores/sidebarStore.ts
+++ b/stores/sidebarStore.ts
@@ -1,0 +1,21 @@
+"use client"
+
+import { create } from "zustand"
+
+// 사이드바 열림/닫힘 상태 전역 관리
+// - 루트 레이아웃은 서버 컴포넌트 유지
+// - Header/Sidebar 등 클라이언트 컴포넌트에서 공용 사용
+
+type SidebarState = {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+  toggle: () => void
+}
+
+export const useSidebarStore = create<SidebarState>((set, get) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+  toggle: () => set({ isOpen: !get().isOpen }),
+}))


### PR DESCRIPTION
Why
- Header에서 Sidebar를 조작해야 하는 요구
- 루트 레이아웃(RSC) 오염 없이 상태 공유 필요
- 모바일에서 배경 스크롤 방지 및 닫힘 동작 일관화


What
- stores/sidebarStore.ts 신설: isOpen/open/close/toggle
- Sidebar 전역 제어로 마이그레이션, 오버레이/링크/라우트 변경/ESC 시 close
- hooks/ui/useBodyScrollLock.ts 신설: 모바일 전용 body 스크롤 락
- HeaderLeft에 햄버거 버튼 추가 및 a11y(aria-controls/expanded)
- docs/daily/2025-09-10.md에 구현 로그 추가

How (Key Changes)
- Sidebar: useSidebarStore, id="app-sidebar", matchMedia(≤767px) 시 자동 close, ESC 처리
- useBodyScrollLock: position: fixed + touch-action/overscroll-behavior, 레퍼런스 카운트로 안전한 lock/unlock
- HeaderLeft: toggle 연동, 불필요한 이동 버튼 제거

Test Plan
- 모바일: 햄버거 토글/오버레이/링크/ESC/라우트 변경 시 Sidebar 닫힘
- 데스크탑: Sidebar 상시 열림(md 이상) 유지
- npm run typecheck, npm run lint 통과