### PR TITLE
[feat] : chat 모바일 단일 패널 전환(mobileView) 도입

### DIFF
--- a/app/dashboard/_components/tokenSection/TokenHistoryTr.tsx
+++ b/app/dashboard/_components/tokenSection/TokenHistoryTr.tsx
@@ -1,56 +1,62 @@
-import type { Database } from "@/types/database.types";
+import type { Database } from "@/types/database.types"
 
-type TokenTransaction = Database['public']['Tables']['token_transactions']['Row'];
+type TokenTransaction = Database["public"]["Tables"]["token_transactions"]["Row"]
 
 // 안전한 날짜 포맷팅 함수
 function formatDate(dateString: string | null): string {
-  if (!dateString) return '날짜 없음';
-  
-  const date = new Date(dateString);
-  if (isNaN(date.getTime())) return '잘못된 날짜';
-  
-  return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit'
-  });
+  if (!dateString) return "날짜 없음"
+
+  const date = new Date(dateString)
+  if (isNaN(date.getTime())) return "잘못된 날짜"
+
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
 }
 
 // 트랜잭션 타입별 라벨과 색상 클래스를 반환
-function getTransactionTypeDisplay(type: TokenTransaction['transaction_type']): { label: string; className: string } {
+function getTransactionTypeDisplay(type: TokenTransaction["transaction_type"]): {
+  label: string
+  className: string
+} {
   switch (type) {
-    case 'CHARGE': return { label: '충전', className: 'text-blue-400' }; // 파란색
-    case 'EARN': return { label: '획득', className: 'text-green-400' }; // 초록색
-    case 'SPEND': return { label: '사용', className: 'text-red-400' }; // 빨간색
-    case 'REFUND': return { label: '환불', className: 'text-yellow-400' }; // 노란색
-    default: return { label: '알 수 없음', className: 'badge badge-neutral' };
+    case "CHARGE":
+      return { label: "충전", className: "text-blue-400 font-semibold" } // 파란색
+    case "EARN":
+      return { label: "획득", className: "text-green-400 font-semibold" } // 초록색
+    case "SPEND":
+      return { label: "사용", className: "text-red-400 font-semibold" } // 빨간색
+    case "REFUND":
+      return { label: "환불", className: "text-yellow-400 font-semibold" } // 노란색
+    default:
+      return { label: "알 수 없음", className: "badge badge-neutral font-semibold" }
   }
 }
 
 // 금액 포맷팅 (천단위 콤마 + 부호)
-function formatAmount(type: TokenTransaction['transaction_type'], amount: number): string {
-  const isPositive = type === 'CHARGE' || type === 'EARN' || type === 'REFUND';
-  const sign = isPositive ? '+' : '-';
-  const formattedAmount = amount.toLocaleString('ko-KR');
-  return `${sign}${formattedAmount}`;
+function formatAmount(type: TokenTransaction["transaction_type"], amount: number): string {
+  const isPositive = type === "CHARGE" || type === "EARN" || type === "REFUND"
+  const sign = isPositive ? "+" : "-"
+  const formattedAmount = amount.toLocaleString("ko-KR")
+  return `${sign}${formattedAmount}`
 }
 
 export default function TokenHistoryTr({ transaction }: { transaction: TokenTransaction }) {
-  console.log("props - transaction : ", transaction);
-  const typeDisplay = getTransactionTypeDisplay(transaction.transaction_type);
-  
+  console.log("props - transaction : ", transaction)
+  const typeDisplay = getTransactionTypeDisplay(transaction.transaction_type)
+
   return (
     <tr key={transaction.transaction_id}>
       <td>{formatDate(transaction.created_at)}</td>
       <td>
-        <span className={typeDisplay.className}>
-          {typeDisplay.label}
-        </span>
+        <span className={typeDisplay.className}>{typeDisplay.label}</span>
       </td>
       <td>{formatAmount(transaction.transaction_type, transaction.amount)}</td>
       <td>
-        <span className="badge badge-success">완료</span>
+        <span className="badge badge-success font-semibold">완료</span>
       </td>
     </tr>
-  );
+  )
 }

--- a/app/dashboard/chat/_components/ChatHeader.tsx
+++ b/app/dashboard/chat/_components/ChatHeader.tsx
@@ -1,7 +1,11 @@
 // app/dashboard/chat/_components/ChatHeader.tsx
-'use client'
+"use client"
 
-import { getAvatarUrl } from '../_utils/avatar'
+import { ArrowLeftToLine } from "lucide-react"
+
+import { useChatUiStore } from "@/stores/chatUiStore"
+
+import { getAvatarUrl } from "../_utils/avatar"
 
 interface ChatHeaderProps {
   otherUser: {
@@ -14,15 +18,27 @@ interface ChatHeaderProps {
 }
 
 export default function ChatHeader({ otherUser, onReservationClick }: ChatHeaderProps) {
+  const setMobileView = useChatUiStore((s) => s.setMobileView)
+
   return (
     <div className="p-4 border-b flex items-center gap-3">
+      {/* 모바일 전용 뒤로가기 버튼 */}
+      <button
+        type="button"
+        className="btn btn-ghost btn-sm md:hidden"
+        onClick={() => setMobileView("list")}
+        aria-label="뒤로가기"
+      >
+        <ArrowLeftToLine />
+      </button>
+
       <div className="avatar">
         <div className="w-12 rounded-full">
           <img src={getAvatarUrl(otherUser)} alt="avatar" />
         </div>
       </div>
       <div className="flex-1">
-        <h2 className="font-bold">{otherUser?.name || '알 수 없는 사용자'}</h2>
+        <h2 className="font-bold">{otherUser?.name || "알 수 없는 사용자"}</h2>
         <div className="flex items-center gap-2">
           {otherUser?.is_online ? (
             <span className="text-sm text-green-500">● 온라인</span>
@@ -30,10 +46,7 @@ export default function ChatHeader({ otherUser, onReservationClick }: ChatHeader
             <span className="text-sm text-gray-500">● 오프라인</span>
           )}
           <div className="flex items-center gap-2">
-            <button
-              className="btn btn-primary btn-sm"
-              onClick={onReservationClick}
-            >
+            <button className="btn btn-primary btn-sm" onClick={onReservationClick}>
               예약하기
             </button>
           </div>

--- a/app/dashboard/chat/_components/ChatList.tsx
+++ b/app/dashboard/chat/_components/ChatList.tsx
@@ -33,6 +33,7 @@ function ChatSkeleton() {
 export default function ChatList() {
   // UI 상태는 chatUiStore에서 가져오기
   const { selectedChat, setSelectedChat, searchTerm: globalSearchTerm } = useChatUiStore()
+  const setMobileView = useChatUiStore((s) => s.setMobileView)
   const [currentUserId, setCurrentUserId] = useState<string | null>(null)
 
   // React Query로 채팅방 목록 가져오기 (새로운 훅 사용)
@@ -70,6 +71,8 @@ export default function ChatList() {
 
   const handleSelectChat = (chatRoom: ChatRoom) => {
     setSelectedChat(chatRoom)
+    // 모바일에서는 대화창으로 전환
+    setMobileView("room")
   }
 
   const renderChatRooms = () => {

--- a/app/dashboard/chat/_components/ChatRoom.tsx
+++ b/app/dashboard/chat/_components/ChatRoom.tsx
@@ -88,7 +88,7 @@ export default function ChatRoom() {
   // 채팅방이 선택되지 않은 경우 안내 화면
   if (!selectedChat || !selectedChat.otherUser) {
     return (
-      <div className="flex-1 bg-base-100 rounded-lg shadow-xl h-full">
+      <div className="flex-1 bg-base-100 rounded-lg shadow-xl h-full w-full ">
         <div className="h-full flex flex-col items-center justify-center text-center p-6">
           <div className="max-w-md">
             <h2 className="text-2xl font-bold mb-2">채팅방을 선택해 주세요</h2>
@@ -103,7 +103,7 @@ export default function ChatRoom() {
 
   return (
     <>
-      <div className="h-full flex flex-col">
+      <div className="h-full flex flex-col w-full">
         {/* 채팅방 헤더 */}
         <ChatHeader
           otherUser={selectedChat.otherUser}

--- a/app/dashboard/chat/_components/LeftSection.tsx
+++ b/app/dashboard/chat/_components/LeftSection.tsx
@@ -4,15 +4,26 @@ import type { ReactNode } from "react"
 import { useEffect } from "react"
 
 import { useChatUiStore } from "@/stores/chatUiStore"
+import { cn } from "@/utils/classname"
 
 export default function LeftSection({ children }: { children: ReactNode }) {
-  const reset = useChatUiStore((s) => s.reset)
+  const setSearchTerm = useChatUiStore((s) => s.setSearchTerm)
+  const mobileView = useChatUiStore((s) => s.mobileView)
 
-  // 페이지 입장/이탈 시 검색어 초기화
+  // 페이지 입장/이탈 시 검색어만 초기화 (선택된 채팅은 유지)
   useEffect(() => {
-    reset()
-    return () => reset()
-  }, [reset])
+    setSearchTerm("")
+    return () => setSearchTerm("")
+  }, [setSearchTerm])
 
-  return <div className="w-80 bg-base-100 rounded-lg shadow-xl flex flex-col">{children}</div>
+  return (
+    <div
+      className={cn(
+        "bg-base-100 rounded-lg shadow-xl h-full w-full md:w-80 flex-col",
+        mobileView === "room" ? "hidden md:flex" : "flex",
+      )}
+    >
+      {children}
+    </div>
+  )
 }

--- a/app/dashboard/chat/_components/RightSection.tsx
+++ b/app/dashboard/chat/_components/RightSection.tsx
@@ -1,10 +1,19 @@
+"use client"
 
-export default function RightSection({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+import { useChatUiStore } from "@/stores/chatUiStore"
+import { cn } from "@/utils/classname"
+
+export default function RightSection({ children }: { children: React.ReactNode }) {
+  const mobileView = useChatUiStore((s) => s.mobileView)
+
   return (
-    <div className="flex-1 bg-base-100 rounded-lg shadow-xl">{children}</div>
-  );
+    <div
+      className={cn(
+        "bg-base-100 rounded-lg shadow-xl h-full flex-1",
+        mobileView === "room" ? "flex" : "hidden md:flex",
+      )}
+    >
+      {children}
+    </div>
+  )
 }

--- a/app/dashboard/chat/_components/SearchChatInput.tsx
+++ b/app/dashboard/chat/_components/SearchChatInput.tsx
@@ -1,18 +1,18 @@
-'use client'
+"use client"
 
-import { useEffect, useMemo, useState } from 'react'
-import debounce from 'lodash/debounce'
+import { useEffect, useMemo, useState } from "react"
+import debounce from "lodash/debounce"
 
-import { useChatUiStore } from '@/stores/chatUiStore'
+import { useChatUiStore } from "@/stores/chatUiStore"
 
 export default function SearchChatInput() {
-  const [value, setValue] = useState('')
+  const [value, setValue] = useState("")
   const setSearchTerm = useChatUiStore((s) => s.setSearchTerm)
 
   // 디바운스된 업데이트 함수 (상태 없이 수행)
   const debouncedUpdate = useMemo(
     () => debounce((q: string) => setSearchTerm(q), 250),
-    [setSearchTerm]
+    [setSearchTerm],
   )
 
   useEffect(() => {
@@ -33,7 +33,7 @@ export default function SearchChatInput() {
 
   return (
     <div className="p-4 border-b">
-      <h1 className="text-2xl font-bold mb-4">Inbox</h1>
+      <h1 className="text-2xl font-bold mb-4">채팅</h1>
       <div className="form-control">
         <form onSubmit={handleSearch} className="flex input-group">
           <input

--- a/app/dashboard/chat/_hooks/ChatPageContainer.tsx
+++ b/app/dashboard/chat/_hooks/ChatPageContainer.tsx
@@ -21,5 +21,7 @@ interface ChatRoom {
 }
 
 export default function ChatPageContainer({ children }: { children: ReactNode }) {
-  return <div className="flex  h-[calc(100vh-4rem)] gap-4">{children}</div>
+  return (
+    <div className="flex flex-col md:flex-row h-[calc(100vh-4rem)] gap-2 md:gap-4">{children}</div>
+  )
 }

--- a/hooks/chat/useStartChat.ts
+++ b/hooks/chat/useStartChat.ts
@@ -12,6 +12,7 @@ export function useStartChat() {
   const router = useRouter()
   const { user: loggedInUser } = useAuthStore()
   const { setSelectedChat } = useChatUiStore()
+  const setMobileView = useChatUiStore((s) => s.setMobileView)
 
   // 새로운 React Query 훅들 사용
   const createChatRoomMutation = useCreateChatRoom()
@@ -42,6 +43,8 @@ export function useStartChat() {
       // 채팅방 상세 조회 후 UI 상태 업데이트
       const chatRoom = await chatApi.getChatRoom(chatRoomId)
       setSelectedChat(chatRoom)
+      // 모바일 환경에서 바로 대화창으로 전환
+      setMobileView("room")
       router.push("/dashboard/chat")
       toast.dismiss()
     } catch (err: unknown) {

--- a/stores/chatUiStore.ts
+++ b/stores/chatUiStore.ts
@@ -8,10 +8,13 @@ type ChatUiState = {
   // 채팅 UI 상태
   searchTerm: string
   selectedChat: ChatRoom | null
+  // 모바일 뷰 상태: 768px 미만에서는 list(목록) 또는 room(대화창) 중 하나만 노출
+  mobileView: "list" | "room"
 
   // UI 액션
   setSearchTerm: (q: string) => void
   setSelectedChat: (chat: ChatRoom | null) => void
+  setMobileView: (view: "list" | "room") => void
   reset: () => void
 }
 
@@ -19,9 +22,11 @@ export const useChatUiStore = create<ChatUiState>((set) => ({
   // 초기 상태
   searchTerm: "",
   selectedChat: null,
+  mobileView: "list",
 
   // 액션
   setSearchTerm: (q) => set({ searchTerm: q }),
   setSelectedChat: (chat) => set({ selectedChat: chat }),
-  reset: () => set({ searchTerm: "", selectedChat: null }),
+  setMobileView: (view) => set({ mobileView: view }),
+  reset: () => set({ searchTerm: "", selectedChat: null, mobileView: "list" }),
 }))


### PR DESCRIPTION
WHY
- 모바일(≤768px) 환경에서 목록/대화창을 동시에 보여주면 가독성과 조작성 저하
- 사용자 요구사항: 목록→대화 전환, 대화창에서 목록으로 돌아가는 “뒤로가기” 버튼 제공(실제 라우팅 이동 아님)
- 기존 에러 처리 구조(QuerySectionBoundary, ClientErrorBoundary)를 유지하면서 최소 변경으로 UX 개선 필요

WHAT
- 전역 UI 상태 도입: `stores/chatUiStore.ts`
  - `mobileView: 'list' | 'room'` 추가, `setMobileView(view)` 액션 제공
  - `reset()` 시 `mobileView`를 `'list'`로 초기화
- 목록 섹션: `app/dashboard/chat/_components/LeftSection.tsx`
  - 모바일에서 `mobileView === 'room'`이면 숨김, 그 외 표시(`hidden md:flex` 토글)
  - 폭: `w-full md:w-80`로 반응형 지정, `flex-col` 유지
  - 입장/이탈 시 검색어만 초기화(`setSearchTerm("")`), 선택된 채팅은 유지
- 대화 섹션: `app/dashboard/chat/_components/RightSection.tsx`
  - 클라이언트 컴포넌트로 전환
  - 모바일에서 `mobileView === 'room'`일 때만 표시, 데스크톱에서는 항상 표시
- 채팅 목록 클릭 전환: `app/dashboard/chat/_components/ChatList.tsx`
  - 항목 선택 시 `setSelectedChat(chatRoom)` 후 `setMobileView('room')`
- 뒤로가기 버튼: `app/dashboard/chat/_components/ChatHeader.tsx`
  - 모바일 전용(`md:hidden`) 뒤로가기 버튼 추가 → `setMobileView('list')`
  - 아이콘: `lucide-react`의 `ArrowLeftToLine` 사용
- 레이아웃: `app/dashboard/chat/_hooks/ChatPageContainer.tsx`
  - `flex-col md:flex-row`, `gap-2 md:gap-4`로 반응형 스택/2열 전환
- 외부에서 채팅 시작: `hooks/chat/useStartChat.ts`
  - 방 진입 시 모바일은 `setMobileView('room')`로 자동 전환 후 `/dashboard/chat` 이동
- UI 정합성: `app/dashboard/chat/_components/ChatRoom.tsx`
  - 모바일 전폭 보장을 위해 일부 컨테이너에 `w-full` 보강
- 에러 경계: `QuerySectionBoundary`/`ChatRoomBoundary` 구성 유지(부분 리렌더링 선호 정책 준수)

HOW
- 표시 토글: Tailwind 유틸리티로 제어
  - 목록: `mobileView === 'room' ? 'hidden md:flex' : 'flex'`
  - 대화: `mobileView === 'room' ? 'flex' : 'hidden md:flex'`
- 폭/레이아웃: `w-full md:w-80`, `flex-1`, `flex-col md:flex-row`
- 상태 기본값: `mobileView` 기본 `'list'`, `reset()` 시 복원
- 라우팅 변경 없음, 순수 UI 상태 전환만 수행

TEST PLAN
1) 모바일(≤768px)
   - 초기 진입 시 목록만 표시됨
   - 목록 항목 클릭 시 대화창으로 전환됨
   - 대화창 상단의 “뒤로가기(← 목록)” 버튼으로 목록으로 복귀
   - 선택 강조, 읽음 처리(알림/뮤테이션) 정상 동작 확인
2) 데스크톱(≥768px)
   - 목록과 대화창이 동시에 표시됨(기존 UX 유지)
   - 목록 선택 시 대화창 내용 갱신 및 선택 강조 유지
3) 접근성/기능
   - 뒤로가기 버튼 `aria-label="뒤로가기"` 제공
   - 에러/로딩은 기존 `QuerySectionBoundary`/스켈레톤 UI로 부분 리렌더링 유지
