### PR TITLE
[feat] : 헤더 SearchBar 사용자 검색 드롭다운 구현(API/Repo/Hook/UI/접근성/키보드 탐색)

### DIFF
--- a/app/api/search/users/route.ts
+++ b/app/api/search/users/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { handleApiError, createValidationError } from "@/app/apis/base"
+import { profileSearchGetQuerySchema } from "@/libs/schemas/server/profile.schema"
+import { searchProfilesByQuery } from "@/app/apis/repository/profile/searchRepository"
+
+export async function GET(request: NextRequest) {
+  try {
+    const url = new URL(request.url)
+    const raw = Object.fromEntries(url.searchParams)
+
+    const parsed = profileSearchGetQuerySchema.safeParse(raw)
+    if (!parsed.success) {
+      const details = parsed.error.flatten().fieldErrors
+      throw createValidationError("요청 파라미터가 유효하지 않습니다.", details)
+    }
+
+    const q = parsed.data.q
+    const limit = Math.max(1, Math.min(20, Number(url.searchParams.get("limit") || "8")))
+
+    const items = await searchProfilesByQuery(q, limit)
+    return NextResponse.json({ items })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/app/apis/repository/profile/searchRepository.ts
+++ b/app/apis/repository/profile/searchRepository.ts
@@ -1,0 +1,52 @@
+"use server"
+
+import { getServerSupabase, wrapRepo } from "@/app/apis/base"
+import type { Database } from "@/types/database.types"
+
+export type UserSearchItem = {
+  profile_id: string
+  public_id: number
+  user_id: string
+  username: string | null
+  nickname: string | null
+  profile_circle_img: string | null
+  is_online: boolean | null
+  name: string | null
+}
+
+export async function searchProfilesByQuery(q: string, limit = 8): Promise<UserSearchItem[]> {
+  const ilike = `%${q}%`
+  return wrapRepo("profile.searchProfilesByQuery", async () => {
+    const supabase = await getServerSupabase()
+    type JoinedRow = Database["public"]["Tables"]["profiles"]["Row"] & {
+      users?: Pick<
+        Database["public"]["Tables"]["users"]["Row"],
+        "id" | "profile_circle_img" | "is_online" | "name"
+      > | null
+    }
+
+    const { data, error } = await supabase
+      .from("profiles")
+      .select(
+        `id, public_id, username, nickname, user_id,
+         users:users!profiles_user_id_fkey(id, profile_circle_img, is_online, name)`,
+      )
+      .or(`username.ilike.${ilike},nickname.ilike.${ilike}`)
+      .limit(limit)
+
+    if (error) throw error
+
+    return (
+      (data as JoinedRow[] | null)?.map((row) => ({
+        profile_id: row.id,
+        public_id: row.public_id,
+        user_id: row.user_id ?? "",
+        username: row.username,
+        nickname: row.nickname,
+        profile_circle_img: row.users?.profile_circle_img ?? null,
+        is_online: row.users?.is_online ?? null,
+        name: row.users?.name ?? null,
+      })) ?? []
+    )
+  })
+}

--- a/app/dashboard/_components/header/SearchBar.tsx
+++ b/app/dashboard/_components/header/SearchBar.tsx
@@ -1,31 +1,192 @@
-"use client";
+"use client"
 
-import { useState } from "react";
-import { Search } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react"
+import { Loader2, Search } from "lucide-react"
+import Image from "next/image"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useQueryClient } from "@tanstack/react-query"
+import { DEFAULT_AVATAR_SRC } from "@/constants/image"
+import { useUserSearchLive } from "@/hooks/api/profile/useUserSearchLive"
+import debounce from "lodash/debounce"
+import { queryKeys } from "@/constants/queryKeys"
 
 export default function SearchBar() {
-  const [isSearchOpen, setIsSearchOpen] = useState<boolean>(false);
+  const [isSearchOpen, setIsSearchOpen] = useState<boolean>(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const latestSearchRef = useRef<(v: string) => void>(() => {})
+  const [len, setLen] = useState(0)
+  const [activeIndex, setActiveIndex] = useState<number>(-1)
+  const router = useRouter()
+  const qc = useQueryClient()
+
+  // 수동 refetch 기반 라이브 검색 훅(내부 상태 보유 X, 입력값은 ref로 관리)
+  const { data, isFetching, isError, search } = useUserSearchLive(8)
+  // 최신 search 콜백을 ref에 유지해 디바운스 인스턴스가 재생성되지 않도록 함
+  useEffect(() => {
+    latestSearchRef.current = search
+  }, [search])
+  const items = data?.items ?? []
+
+  // 입력 이벤트에 바로 연결 가능한 디바운스 함수(1회 생성)
+  const debouncedSearch = useMemo(
+    () => debounce((v: string) => latestSearchRef.current(v), 300),
+    [],
+  )
+  useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch])
+
+  const handleBlur: React.FocusEventHandler<HTMLDivElement> = (e) => {
+    const next = e.relatedTarget as Node | null
+    if (next && containerRef.current?.contains(next)) return
+    // 남아있는 대기 호출 취소
+    debouncedSearch.cancel()
+    // 인플라이트 쿼리 취소
+    void qc.cancelQueries({ queryKey: queryKeys.search.users("live") })
+    setIsSearchOpen(false)
+  }
+
+  // 선택 이동 시 가시 영역으로 스크롤
+  useEffect(() => {
+    if (activeIndex < 0) return
+    const id = `search-users-option-${activeIndex}`
+    document.getElementById(id)?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex])
+
+  // 결과 변화/표시 조건 변화에 따라 activeIndex를 안전하게 보정
+  useEffect(() => {
+    if (len < 2) {
+      if (activeIndex !== -1) setActiveIndex(-1)
+      return
+    }
+    if (items.length === 0) {
+      if (activeIndex !== -1) setActiveIndex(-1)
+      return
+    }
+    if (activeIndex >= items.length) {
+      setActiveIndex(items.length - 1)
+    }
+  }, [items.length, len, activeIndex])
 
   return (
-    <>
+    <div ref={containerRef} className="relative" onBlur={handleBlur}>
       {isSearchOpen ? (
         <div className="flex items-center gap-2 mr-4">
-          <input
-            type="text"
-            placeholder="닉네임 혹은 태그명을 입력하세요"
-            className="input input-ghost w-full max-w-xs h-8 text-sm"
-            autoFocus
-            onBlur={() => setIsSearchOpen(false)}
-          />
+          <div className="relative">
+            <input
+              type="text"
+              ref={inputRef}
+              onChange={(e) => {
+                const v = e.target.value
+                setLen(v.trim().length) // 드롭다운 표시 상태만 담당
+                debouncedSearch(v) // 네트워크 요청은 디바운스
+                setActiveIndex(-1) // 입력이 바뀌면 선택 초기화
+              }}
+              placeholder="닉네임 또는 사용자명을 입력하세요(2자 이상)"
+              className="input input-ghost w-full max-w-xs h-8 text-sm pr-7"
+              autoFocus
+              role="combobox"
+              aria-expanded={isSearchOpen}
+              aria-controls="search-users-listbox"
+              aria-activedescendant={
+                activeIndex >= 0 ? `search-users-option-${activeIndex}` : undefined
+              }
+              aria-autocomplete="list"
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  debouncedSearch.cancel()
+                  void qc.cancelQueries({ queryKey: queryKeys.search.users("live") })
+                  setIsSearchOpen(false)
+                } else if (e.key === "ArrowDown") {
+                  e.preventDefault()
+                  setActiveIndex((prev) => Math.min(items.length - 1, prev + 1))
+                } else if (e.key === "ArrowUp") {
+                  e.preventDefault()
+                  setActiveIndex((prev) => Math.max(-1, prev - 1))
+                } else if (e.key === "Enter") {
+                  if (activeIndex >= 0 && items[activeIndex]) {
+                    const to = `/profile/${items[activeIndex].public_id}`
+                    debouncedSearch.cancel()
+                    void qc.cancelQueries({ queryKey: queryKeys.search.users("live") })
+                    setIsSearchOpen(false)
+                    router.push(to)
+                  }
+                }
+              }}
+            />
+            <div className="pointer-events-none absolute right-2 top-1.5 text-base-content/60">
+              {isFetching ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Search className="w-4 h-4" />
+              )}
+            </div>
+          </div>
+
+          {/* 드롭다운 */}
+          {len >= 2 && (
+            <div className="absolute right-0 top-[110%] z-50 w-[22rem] max-w-[90vw] rounded-lg border bg-base-100 shadow-lg">
+              <ul id="search-users-listbox" role="listbox" className="max-h-80 overflow-auto py-2">
+                {isFetching && items.length === 0 ? (
+                  <li className="px-4 py-3 text-sm text-base-content/60">검색 중…</li>
+                ) : isError ? (
+                  <li className="px-4 py-3 text-sm text-error">검색 중 오류가 발생했습니다</li>
+                ) : items.length === 0 ? (
+                  <li className="px-4 py-3 text-sm text-base-content/60">
+                    일치하는 사용자가 없습니다
+                  </li>
+                ) : (
+                  items.map((u, idx) => (
+                    <li
+                      key={u.profile_id}
+                      id={`search-users-option-${idx}`}
+                      role="option"
+                      aria-selected={activeIndex === idx}
+                      className="px-2"
+                      onMouseEnter={() => setActiveIndex(idx)}
+                    >
+                      <Link
+                        href={`/profile/${u.public_id}`}
+                        className={
+                          `flex items-center gap-3 rounded-md px-2 py-2 focus:outline-none ` +
+                          (activeIndex === idx ? "bg-base-200" : "hover:bg-base-200")
+                        }
+                      >
+                        <div className="relative w-10 h-10 rounded-full overflow-hidden shrink-0">
+                          <Image
+                            src={u.profile_circle_img || DEFAULT_AVATAR_SRC}
+                            alt={u.username ?? u.nickname ?? "profile"}
+                            fill
+                            sizes="40px"
+                            className="object-cover"
+                          />
+                          <span
+                            className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-base-100"
+                            style={{ backgroundColor: u.is_online ? "#0EA5E9" : "#9CA3AF" }}
+                            aria-label={u.is_online ? "온라인" : "오프라인"}
+                          />
+                        </div>
+                        <div className="min-w-0">
+                          <div className="text-sm font-semibold truncate">
+                            {u.username ?? u.name ?? "-"}
+                          </div>
+                          <div className="text-xs text-base-content/60 truncate">
+                            {u.nickname ?? "닉네임 없음"}
+                          </div>
+                        </div>
+                      </Link>
+                    </li>
+                  ))
+                )}
+              </ul>
+            </div>
+          )}
         </div>
       ) : (
-        <button
-          className="btn btn-ghost btn-circle"
-          onClick={() => setIsSearchOpen(true)}
-        >
+        <button className="btn btn-ghost btn-circle" onClick={() => setIsSearchOpen(true)}>
           <Search className="w-5 h-5" />
         </button>
       )}
-    </>
-  );
-} 
+    </div>
+  )
+}

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -49,6 +49,10 @@ export const queryKeys = {
     selectedGamesByUserId: (userId: string) => ["profile", "selectedGames", userId] as const,
     reviewsByProfileId: (profileId: string) => ["profile", "reviews", profileId] as const,
   },
+
+  search: {
+    users: (q: string) => ["search", "users", q] as const,
+  },
 } as const
 
 export type QueryKey = ReturnType<
@@ -81,6 +85,7 @@ export type QueryKey = ReturnType<
   | typeof queryKeys.profile.publicById
   | typeof queryKeys.profile.selectedGamesByUserId
   | typeof queryKeys.profile.reviewsByProfileId
+  | typeof queryKeys.search.users
 >
 
 export const legacyQueryKeys = {

--- a/hooks/api/profile/useUserSearch.ts
+++ b/hooks/api/profile/useUserSearch.ts
@@ -1,0 +1,49 @@
+"use client"
+
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query"
+import { queryKeys } from "@/constants/queryKeys"
+
+export type UserSearchItem = {
+  profile_id: string
+  public_id: number
+  user_id: string
+  username: string | null
+  nickname: string | null
+  profile_circle_img: string | null
+  is_online: boolean | null
+  name: string | null
+}
+
+export interface UserSearchResponse {
+  items: UserSearchItem[]
+}
+
+type Options = Omit<
+  UseQueryOptions<
+    UserSearchResponse,
+    Error,
+    UserSearchResponse,
+    ReturnType<typeof queryKeys.search.users>
+  >,
+  "queryKey" | "queryFn"
+>
+
+export function useUserSearch(q: string, limit = 8, options?: Options) {
+  const qKey = q.trim().toLowerCase()
+  return useQuery({
+    queryKey: queryKeys.search.users(qKey),
+    queryFn: async () => {
+      const params = new URLSearchParams({ q, limit: String(limit) })
+      const res = await fetch(`/api/search/users?${params.toString()}`)
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err?.message || "사용자 검색에 실패했습니다")
+      }
+      return (await res.json()) as UserSearchResponse
+    },
+    enabled: qKey.length >= 2,
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/hooks/api/profile/useUserSearchLive.ts
+++ b/hooks/api/profile/useUserSearchLive.ts
@@ -1,0 +1,59 @@
+"use client"
+
+import { useCallback, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { queryKeys } from "@/constants/queryKeys"
+
+export type UserSearchItem = {
+  profile_id: string
+  public_id: number
+  user_id: string
+  username: string | null
+  nickname: string | null
+  profile_circle_img: string | null
+  is_online: boolean | null
+  name: string | null
+}
+
+export interface UserSearchResponse {
+  items: UserSearchItem[]
+}
+
+export function useUserSearchLive(initialLimit = 8) {
+  const qRef = useRef("")
+  const limitRef = useRef(initialLimit)
+
+  const query = useQuery({
+    queryKey: queryKeys.search.users("live"),
+    enabled: false, // 수동 refetch만 사용
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    queryFn: async ({ signal }): Promise<UserSearchResponse> => {
+      const q = qRef.current
+      const limit = String(limitRef.current)
+      const params = new URLSearchParams({ q, limit })
+      const res = await fetch(`/api/search/users?${params.toString()}`, { signal })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err?.message || "사용자 검색에 실패했습니다")
+      }
+      return (await res.json()) as UserSearchResponse
+    },
+  })
+
+  const search = useCallback(
+    (q: string) => {
+      const v = q.trim()
+      qRef.current = v
+      if (v.length >= 2) {
+        void query.refetch()
+      }
+    },
+    [query],
+  )
+
+  return {
+    ...query,
+    search,
+  }
+}

--- a/libs/schemas/server/profile.schema.ts
+++ b/libs/schemas/server/profile.schema.ts
@@ -24,3 +24,14 @@ export const profileSelectedGamesGetQuerySchema = z.object({
 })
 
 export type ProfileSelectedGamesGetQuery = z.infer<typeof profileSelectedGamesGetQuerySchema>
+
+// GET /api/search/users?q=... (username/nickname 검색)
+export const profileSearchGetQuerySchema = z.object({
+  q: z
+    .string({ required_error: "q는 필수입니다." })
+    .trim()
+    .min(1, { message: "검색어는 1자 이상이어야 합니다." })
+    .max(50, { message: "검색어는 50자 이하여야 합니다." }),
+})
+
+export type ProfileSearchGetQuery = z.infer<typeof profileSearchGetQuerySchema>


### PR DESCRIPTION
WHY
- 헤더는 전역 고정 컴포넌트로 입력 중 불필요 렌더 최소화가 중요
- 빠른 타이핑 중 불필요 요청 억제와 늦은 응답 오염 방지를 위해 디바운스+Abort 필요
- 접근성(ARIA) 및 키보드 탐색은 검색 UX의 기본

WHAT
- queryKeys.ts: search.users(q) 쿼리 키 추가
- profile.schema.ts: profileSearchGetQuerySchema(q: 1~50자) 추가
- searchRepository.ts: username/nickname ILIKE OR + users 조인, 경량 DTO 매핑
- route.ts: GET /api/search/users?q&limit, Zod 검증 + handleApiError 표준화
- useUserSearchLive.ts: enabled:false + 수동 refetch, queryFn({signal})로 Abort 지원
- SearchBar.tsx:
  - 언컨트롤드 input + lodash.debounce(300ms)
  - latestSearchRef로 디바운스 콜백 안정화(인스턴스 1회 생성)
  - blur/ESC 시 디바운스 취소 + queryClient.cancelQueries로 인플라이트 취소
  - 드롭다운 표시 len 상태 분리(표시/요청 분리), next/link, avatar 폴백, 온라인 배지
  - 키보드 탐색(↑/↓/Enter) + aria-activedescendant/role 속성, 활성 항목 scrollIntoView

TEST
- 2자 이상 입력 → 300ms 후 요청/로딩 스피너
- ↑/↓로 항목 이동, Enter로 이동, ESC/blur로 닫기
- 빠른 타이핑에서 이전 요청이 취소되어 후착 응답이 UI를 덮지 않음