### PR TITLE
[refactor] : chat - 낙관적 전송 도입, 입력 포커스 유지, Realtime 무효화 키 중앙화

### DIFF
--- a/app/dashboard/chat/_components/ChatInput.tsx
+++ b/app/dashboard/chat/_components/ChatInput.tsx
@@ -1,40 +1,39 @@
 // app/dashboard/chat/_components/ChatInput.tsx
-'use client'
+"use client"
 
-import { useState, FormEvent } from 'react'
+import { useState, FormEvent, useRef } from "react"
 
 interface ChatInputProps {
   onSendMessage: (content: string) => void
-  isDisabled: boolean
+  isSubmitting: boolean
 }
 
-export default function ChatInput({ onSendMessage, isDisabled }: ChatInputProps) {
-  const [messageText, setMessageText] = useState('')
+export default function ChatInput({ onSendMessage, isSubmitting }: ChatInputProps) {
+  const [messageText, setMessageText] = useState("")
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()
     if (!messageText.trim()) return
 
     onSendMessage(messageText)
-    setMessageText('')
+    setMessageText("")
+    // 전송 후에도 입력 포커스를 유지하여 연속 입력 UX 개선
+    queueMicrotask(() => inputRef.current?.focus())
   }
 
   return (
     <form onSubmit={handleSubmit} className="p-4 border-t">
       <div className="flex gap-2 items-center">
         <input
+          ref={inputRef}
           type="text"
           value={messageText}
           onChange={(e) => setMessageText(e.target.value)}
           placeholder="메시지를 입력하세요..."
           className="input input-bordered flex-1 h-10"
-          disabled={isDisabled}
         />
-        <button
-          type="submit"
-          className="btn btn-primary"
-          disabled={isDisabled}
-        >
+        <button type="submit" className="btn btn-primary" disabled={isSubmitting}>
           전송
         </button>
       </div>

--- a/app/dashboard/chat/_components/ChatRoom.tsx
+++ b/app/dashboard/chat/_components/ChatRoom.tsx
@@ -7,7 +7,7 @@ import { useAuthStore } from "@/stores/authStore"
 import { useChatUiStore } from "@/stores/chatUiStore"
 import { useNotificationStore } from "@/stores/notificationStore"
 import { useChatMessages } from "@/hooks/api/chat/useChatQueries"
-import { useSendMessage, useMarkAsRead } from "@/hooks/api/chat/useChatMutations"
+import { useOptimisticSendMessage, useMarkAsRead } from "@/hooks/api/chat/useChatMutations"
 
 import ReservationModal from "./reserveModal/ReservationModal"
 import ChatHeader from "./ChatHeader"
@@ -29,7 +29,7 @@ export default function ChatRoom() {
 
   // 새로운 React Query 훅들 사용
   const { data: messages = [], isLoading } = useChatMessages(roomId)
-  const sendMessageMutation = useSendMessage()
+  const optimisticSendMessage = useOptimisticSendMessage()
   const { mutate: markAsRead } = useMarkAsRead()
 
   // 알림 스토어는 필요한 액션만 셀렉터로 구독하여 불필요 리렌더 방지
@@ -66,13 +66,13 @@ export default function ChatRoom() {
         return
       }
 
-      sendMessageMutation.mutate({
+      optimisticSendMessage.mutate({
         content,
         receiverId: selectedChat.otherUser.id,
         chatRoomId: roomId || undefined,
       })
     },
-    [selectedChat?.otherUser?.id, roomId, sendMessageMutation],
+    [selectedChat?.otherUser?.id, roomId, optimisticSendMessage],
   )
 
   // 예약 버튼 클릭 핸들러 - 참조 안정성 확보
@@ -116,7 +116,7 @@ export default function ChatRoom() {
         {/* 메시지 입력 */}
         <ChatInput
           onSendMessage={handleSendMessage}
-          isDisabled={isLoading || sendMessageMutation.isPending}
+          isSubmitting={optimisticSendMessage.isPending}
         />
       </div>
 

--- a/app/dashboard/chat/_hooks/useMessageSubscription.ts
+++ b/app/dashboard/chat/_hooks/useMessageSubscription.ts
@@ -8,7 +8,7 @@ import { RealtimeChannel, RealtimePostgresChangesPayload } from "@supabase/supab
 
 import { Database } from "@/types/database.types"
 import { Message } from "@/app/dashboard/chat/_types/chatTypes"
-import { ChatQueryKeys } from "@/app/dashboard/chat/_api"
+import { queryKeys } from "@/constants/queryKeys"
 import { useNotificationStore } from "@/stores/notificationStore"
 
 export const useMessageSubscription = (currentChatRoomId: string | null) => {
@@ -34,9 +34,9 @@ export const useMessageSubscription = (currentChatRoomId: string | null) => {
 
           // 새 메시지의 채팅방과 현재 보고 있는 채팅방이 같은 경우
           if (currentChatRoomId && currentChatRoomId === newMessage.chat_room_id) {
-            // 메시지 캐시 무효화 - React Query v4 형식으로 수정
+            // 메시지 캐시 무효화 - 중앙 쿼리 키 사용
             queryClient.invalidateQueries({
-              queryKey: ["messages", currentChatRoomId],
+              queryKey: queryKeys.chat.messages(currentChatRoomId),
             })
 
             // 새 메시지가 현재 사용자에게 온 경우 읽음 처리 + 알림 읽음 처리
@@ -58,7 +58,7 @@ export const useMessageSubscription = (currentChatRoomId: string | null) => {
           } else {
             // 다른 채팅방에서 메시지가 왔을 경우 채팅방 목록만 업데이트
             queryClient.invalidateQueries({
-              queryKey: ["chatRooms"],
+              queryKey: queryKeys.chat.chatRooms(),
             })
           }
         },
@@ -72,7 +72,7 @@ export const useMessageSubscription = (currentChatRoomId: string | null) => {
         },
         () => {
           // 채팅방 참가자 정보가 업데이트되면 채팅방 목록을 다시 가져오기
-          queryClient.invalidateQueries({ queryKey: ChatQueryKeys.chatRooms })
+          queryClient.invalidateQueries({ queryKey: queryKeys.chat.chatRooms() })
         },
       )
       .subscribe()


### PR DESCRIPTION
WHY
- 내가 보낸 메시지 표시 지연(서버 응답/Realtime 대기)
- 전송 중 input 비활성화로 포커스 이탈, 연속 타이핑 끊김
- 하드코딩된 쿼리 키 → 정밀 무효화 실패/불필요 무효화 가능

WHAT
- useMessageSubscription: 중앙 쿼리 키(queryKeys.chat.messages/chatRooms) 사용
- useOptimisticSendMessage: onMutate/rollback/onSettled 기반 낙관적 전송
- ChatInput: 전송 버튼만 비활성화, 전송 후 포커스 유지
- ChatRoom: 낙관적 전송 훅 적용

HOW
- onMutate: 스냅샷 저장 → 임시 메시지 append → 실패 시 롤백
- onSettled: 방별 메시지/채팅방 목록 재검증
- 실시간 이벤트 시 중앙 키 invalidate