### PR TITLE
[[refactor] : dashboard 토큰 탭, 의뢰 페이지 360px UI 안정화

### DIFF
--- a/app/dashboard/_components/DashboardPageContainer.tsx
+++ b/app/dashboard/_components/DashboardPageContainer.tsx
@@ -1,6 +1,6 @@
 export default function DashboardPageContainer({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen bg-base-200">
+    <div className="flex min-h-screen bg-base-200 w-full min-w-0">
       <div className="min-w-0 flex-1">
         {/* 헤더 */}
         <div className="flex justify-between items-center h-12 mb-7 px-2">

--- a/app/dashboard/_components/DashboardPageContainer.tsx
+++ b/app/dashboard/_components/DashboardPageContainer.tsx
@@ -1,22 +1,15 @@
-export default function DashboardPageContainer({
-    children,
-  }: {
-    children: React.ReactNode
-  }) {
-    return (
-      <div className="flex min-h-screen bg-base-200">
-        <div className="flex-1 p-4">
-          {/* 헤더 */}
-          <div className="flex justify-between items-center h-12 mb-7 px-2">
-            <h1 className="text-2xl md:text-3xl font-bold">마이 페이지</h1>
-          </div>
-  
-          {/* 탭 + 콘텐츠 */}
-          <div className="flex flex-col gap-6">
-            {children}
-          </div>
+export default function DashboardPageContainer({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen bg-base-200">
+      <div className="min-w-0 flex-1">
+        {/* 헤더 */}
+        <div className="flex justify-between items-center h-12 mb-7 px-2">
+          <h1 className="text-2xl md:text-3xl font-bold">마이 페이지</h1>
         </div>
+
+        {/* 탭 + 콘텐츠 */}
+        <div className="flex flex-col gap-6">{children}</div>
       </div>
-    )
-  }
-  
+    </div>
+  )
+}

--- a/app/dashboard/_components/tokenSection/TokenHistoryBoundary.tsx
+++ b/app/dashboard/_components/tokenSection/TokenHistoryBoundary.tsx
@@ -4,11 +4,17 @@ import QuerySectionBoundary from "@/components/query/QuerySectionBoundary"
 import { queryKeys } from "@/constants/queryKeys"
 
 import TokenHistoryTable from "./TokenHistoryTable"
+import TokenHistoryListMobile from "./TokenHistoryListMobile"
 
 export default function TokenHistoryBoundary() {
   return (
     <QuerySectionBoundary keys={queryKeys.token.transactions()}>
-      <TokenHistoryTable />
+      {/* <div className="block sm:hidden">
+        <TokenHistoryListMobile />
+      </div> */}
+      <div className="">
+        <TokenHistoryTable />
+      </div>
     </QuerySectionBoundary>
   )
 }

--- a/app/dashboard/_components/tokenSection/TokenHistoryListMobile.tsx
+++ b/app/dashboard/_components/tokenSection/TokenHistoryListMobile.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import {
+  useTokenTransactionsInfiniteQuery,
+  type TokenTransaction,
+} from "@/hooks/api/token/useTokenTransactionsInfiniteQuery"
+import { formatRelativeFromNow } from "@/utils/date"
+import { Button } from "@/components/ui"
+import LoadingSpinner from "@/components/ui/LoadingSpinner"
+
+function getTransactionTypeDisplay(type: TokenTransaction["transaction_type"]) {
+  switch (type) {
+    case "CHARGE":
+      return { label: "충전", className: "text-blue-400 font-semibold" }
+    case "EARN":
+      return { label: "획득", className: "text-green-400 font-semibold" }
+    case "SPEND":
+      return { label: "사용", className: "text-red-400 font-semibold" }
+    case "REFUND":
+      return { label: "환불", className: "text-yellow-400 font-semibold" }
+    default:
+      return { label: "알 수 없음", className: "badge badge-neutral font-semibold" }
+  }
+}
+
+function formatAmount(type: TokenTransaction["transaction_type"], amount: number) {
+  const isPositive = type === "CHARGE" || type === "EARN" || type === "REFUND"
+  const sign = isPositive ? "+" : "-"
+  const formattedAmount = amount.toLocaleString("ko-KR")
+  return `${sign}${formattedAmount}`
+}
+
+export default function TokenHistoryListMobile() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, error } =
+    useTokenTransactionsInfiniteQuery()
+
+  if (error) return <div className="p-4 text-error text-sm">에러가 발생하였습니다.</div>
+
+  const items = (data?.pages ?? []).flatMap((p) => p.items ?? [])
+
+  return (
+    <div className="card bg-base-100 shadow-xl">
+      <div className="card-body">
+        <h2 className="card-title mb-2">토큰 사용 내역</h2>
+        <div className="space-y-3">
+          {items.map((tx) => {
+            const type = getTransactionTypeDisplay(tx.transaction_type)
+            return (
+              <div
+                key={tx.transaction_id}
+                className="rounded-lg border border-base-300 p-3 flex flex-col gap-1"
+              >
+                <div className="flex justify-between items-baseline">
+                  <span className="text-xs text-base-content/60 whitespace-nowrap">
+                    {formatRelativeFromNow(tx.created_at ?? "")}
+                  </span>
+                  <span className={`${type.className} text-xs whitespace-nowrap`}>
+                    {type.label}
+                  </span>
+                </div>
+                <div className="flex justify-between items-center">
+                  <span className="text-sm font-semibold whitespace-nowrap">
+                    {formatAmount(tx.transaction_type, tx.amount)}
+                  </span>
+                  <span className="badge badge-success px-2 py-0.5 text-[0.7rem] font-semibold">
+                    완료
+                  </span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+        {hasNextPage && (
+          <div className="flex justify-end">
+            <Button variant="default" size="sm" className="mt-2" onClick={() => fetchNextPage()}>
+              {isFetchingNextPage ? <LoadingSpinner size="sm" color="second" /> : "더 보기"}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/_components/tokenSection/TokenHistoryTable.tsx
+++ b/app/dashboard/_components/tokenSection/TokenHistoryTable.tsx
@@ -33,7 +33,7 @@ export default function TokenHistoryTable() {
 
   return (
     <div className="card bg-base-100 shadow-xl">
-      <div className="card-body">
+      <div className="card-body p-2">
         <h2 className="card-title mb-4">토큰 사용 내역</h2>
         <div className="w-full overflow-x-auto">
           <table className="table table-zebra w-full table-auto">

--- a/app/dashboard/_components/tokenSection/TokenHistoryTable.tsx
+++ b/app/dashboard/_components/tokenSection/TokenHistoryTable.tsx
@@ -1,35 +1,42 @@
-"use client";
+"use client"
 
-import { useTokenTransactionsInfiniteQuery, type TokenTransaction } from "@/hooks/api/token/useTokenTransactionsInfiniteQuery";
+import {
+  useTokenTransactionsInfiniteQuery,
+  type TokenTransaction,
+} from "@/hooks/api/token/useTokenTransactionsInfiniteQuery"
 
-import { Button } from "@/components/ui";
+import { Button } from "@/components/ui"
 
-import TokenHistoryTr from "./TokenHistoryTr";
-import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import TokenHistoryTr from "./TokenHistoryTr"
+import LoadingSpinner from "@/components/ui/LoadingSpinner"
 export default function TokenHistoryTable() {
-  
-  const { data: transactionsData, fetchNextPage, hasNextPage, error, isFetchingNextPage  } =
-    useTokenTransactionsInfiniteQuery();
+  const {
+    data: transactionsData,
+    fetchNextPage,
+    hasNextPage,
+    error,
+    isFetchingNextPage,
+  } = useTokenTransactionsInfiniteQuery()
 
   if (error) {
-    return <div>에러가 발생하였습니다.</div>;
+    return <div>에러가 발생하였습니다.</div>
   }
 
   if (transactionsData) {
-    console.log("전체 transactionsData:", transactionsData);
-    console.log("pages 배열:", transactionsData.pages);
+    console.log("전체 transactionsData:", transactionsData)
+    console.log("pages 배열:", transactionsData.pages)
     transactionsData.pages.forEach((page, index) => {
-      console.log(`page ${index}:`, page);
-      console.log(`page ${index} items:`, page.items);
-    });
+      console.log(`page ${index}:`, page)
+      console.log(`page ${index} items:`, page.items)
+    })
   }
 
   return (
     <div className="card bg-base-100 shadow-xl">
       <div className="card-body">
         <h2 className="card-title mb-4">토큰 사용 내역</h2>
-        <div className="overflow-x-auto">
-          <table className="table table-zebra">
+        <div className="w-full overflow-x-auto">
+          <table className="table table-zebra w-full table-auto">
             <thead>
               <tr>
                 <th>날짜</th>
@@ -40,31 +47,21 @@ export default function TokenHistoryTable() {
             </thead>
             <tbody>
               {transactionsData?.pages.flatMap((page) =>
-                (page.items || []).map((transaction : TokenTransaction) => (
-                  <TokenHistoryTr
-                    key={transaction.transaction_id}
-                    transaction={transaction}
-                  />
-                ))
+                (page.items || []).map((transaction: TokenTransaction) => (
+                  <TokenHistoryTr key={transaction.transaction_id} transaction={transaction} />
+                )),
               )}
             </tbody>
           </table>
           <div className="flex justify-end">
-            
             {hasNextPage && (
-              <Button
-                variant="default"
-                size="sm"
-                className="mt-2"
-                onClick={() => fetchNextPage()}
-              >
-                {isFetchingNextPage ? <LoadingSpinner size="sm" color="second"/> : "더 보기"}
-                
+              <Button variant="default" size="sm" className="mt-2" onClick={() => fetchNextPage()}>
+                {isFetchingNextPage ? <LoadingSpinner size="sm" color="second" /> : "더 보기"}
               </Button>
             )}
           </div>
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/app/dashboard/_components/tokenSection/TokenHistoryTr.tsx
+++ b/app/dashboard/_components/tokenSection/TokenHistoryTr.tsx
@@ -1,20 +1,9 @@
 import type { Database } from "@/types/database.types"
+import { formatRelativeFromNow } from "@/utils/date"
 
 type TokenTransaction = Database["public"]["Tables"]["token_transactions"]["Row"]
 
-// 안전한 날짜 포맷팅 함수
-function formatDate(dateString: string | null): string {
-  if (!dateString) return "날짜 없음"
-
-  const date = new Date(dateString)
-  if (isNaN(date.getTime())) return "잘못된 날짜"
-
-  return date.toLocaleDateString("ko-KR", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  })
-}
+// 날짜는 상대 시간(예: 3시간 전)으로 간략히 표기하여 작은 화면에서의 줄바꿈을 줄입니다.
 
 // 트랜잭션 타입별 라벨과 색상 클래스를 반환
 function getTransactionTypeDisplay(type: TokenTransaction["transaction_type"]): {
@@ -49,13 +38,21 @@ export default function TokenHistoryTr({ transaction }: { transaction: TokenTran
 
   return (
     <tr key={transaction.transaction_id}>
-      <td>{formatDate(transaction.created_at)}</td>
-      <td>
-        <span className={typeDisplay.className}>{typeDisplay.label}</span>
+      <td className="whitespace-nowrap text-xs sm:text-sm">
+        {formatRelativeFromNow(transaction.created_at ?? "")}
       </td>
-      <td>{formatAmount(transaction.transaction_type, transaction.amount)}</td>
-      <td>
-        <span className="badge badge-success font-semibold">완료</span>
+      <td className="whitespace-nowrap text-xs sm:text-sm">
+        <span className={`${typeDisplay.className} text-xs sm:text-sm whitespace-nowrap`}>
+          {typeDisplay.label}
+        </span>
+      </td>
+      <td className="whitespace-nowrap text-xs sm:text-sm font-semibold">
+        {formatAmount(transaction.transaction_type, transaction.amount)}
+      </td>
+      <td className="whitespace-nowrap">
+        <span className="badge badge-success px-2 py-0.5 text-[0.7rem] sm:text-xs font-semibold">
+          완료
+        </span>
       </td>
     </tr>
   )

--- a/app/dashboard/_components/tokenSection/TokenSectionContainer.tsx
+++ b/app/dashboard/_components/tokenSection/TokenSectionContainer.tsx
@@ -1,11 +1,7 @@
-"use client";
+"use client"
 
-import { ReactNode } from "react";
+import { ReactNode } from "react"
 
-export default function TokenSectionContainer({
-  children,
-}: {
-  children: ReactNode;
-}) {
-  return <div className="space-y-6">{children}</div>;
+export default function TokenSectionContainer({ children }: { children: ReactNode }) {
+  return <div className="w-full min-w-0 space-y-6">{children}</div>
 }

--- a/app/dashboard/_components/tokenSection/TokenSummaryCard.tsx
+++ b/app/dashboard/_components/tokenSection/TokenSummaryCard.tsx
@@ -1,21 +1,21 @@
-"use client";
+"use client"
 
-import { useState } from "react";
+import { useState } from "react"
 
-import TokenChargeModal from "../modals/TokenChargeModal";
-import TokenChargeButton from "./TokenChargeButton";
-import { useTokenBalanceQuery, useTokenUsageQuery } from "@/hooks/api/token/useTokenBalanceQuery";
-import { useAuthStore } from "@/stores/authStore";
+import TokenChargeModal from "../modals/TokenChargeModal"
+import TokenChargeButton from "./TokenChargeButton"
+import { useTokenBalanceQuery, useTokenUsageQuery } from "@/hooks/api/token/useTokenBalanceQuery"
+import { useAuthStore } from "@/stores/authStore"
 
 export default function TokenSummaryCard() {
-  const [isChargeModalOpen, setIsChargeModalOpen] = useState<boolean>(false);
+  const [isChargeModalOpen, setIsChargeModalOpen] = useState<boolean>(false)
 
-  const { user } = useAuthStore();
-  const { data: balance, error: balanceError } = useTokenBalanceQuery(user?.id);
-  const { data: usageData, error: usageError } = useTokenUsageQuery();
+  const { user } = useAuthStore()
+  const { data: balance, error: balanceError } = useTokenBalanceQuery(user?.id)
+  const { data: usageData, error: usageError } = useTokenUsageQuery()
 
   if (balanceError || usageError) {
-    return <div>에러가 발생하였습니다.</div>;
+    return <div>에러가 발생하였습니다.</div>
   }
 
   return (
@@ -24,16 +24,15 @@ export default function TokenSummaryCard() {
         <div className="card-body">
           <div className="flex justify-between items-center">
             <h2 className="card-title mb-4">토큰 보유 현황</h2>
-            <TokenChargeButton
-              openChargeModal={() => setIsChargeModalOpen(true)}
-            />
+            <TokenChargeButton openChargeModal={() => setIsChargeModalOpen(true)} />
           </div>
-          <div className="stats shadow">
+          {/* 모바일에서는 세로 스택, sm 이상에서 가로 배치 */}
+          <div className="stats stats-vertical sm:stats-horizontal shadow w-full">
             <div className="stat">
               <div className="stat-title">보유 토큰</div>
               <div className="stat-value">{balance ?? 0}</div>
               <div className="stat-desc">
-                {usageData && typeof usageData.diff === 'number' && !isNaN(usageData.diff)
+                {usageData && typeof usageData.diff === "number" && !isNaN(usageData.diff)
                   ? usageData.diff >= 0
                     ? `↗︎ ${Math.abs(usageData.diff).toLocaleString()} (지난달 대비)`
                     : `↘︎ ${Math.abs(usageData.diff).toLocaleString()} (지난달 대비)`
@@ -43,7 +42,9 @@ export default function TokenSummaryCard() {
             <div className="stat">
               <div className="stat-title">사용 토큰</div>
               <div className="stat-value">
-                {usageData && typeof usageData.usageThisMonth === 'number' && !isNaN(usageData.usageThisMonth)
+                {usageData &&
+                typeof usageData.usageThisMonth === "number" &&
+                !isNaN(usageData.usageThisMonth)
                   ? usageData.usageThisMonth.toLocaleString()
                   : 0}
               </div>
@@ -52,10 +53,7 @@ export default function TokenSummaryCard() {
           </div>
         </div>
       </div>
-      <TokenChargeModal
-        isOpen={isChargeModalOpen}
-        onClose={() => setIsChargeModalOpen(false)}
-      />
+      <TokenChargeModal isOpen={isChargeModalOpen} onClose={() => setIsChargeModalOpen(false)} />
     </>
-  );
+  )
 }

--- a/app/dashboard/task/_components/TaskList.tsx
+++ b/app/dashboard/task/_components/TaskList.tsx
@@ -202,7 +202,7 @@ export default function TaskList() {
   }
 
   return (
-    <div className="p-6">
+    <div className="min-w-0">
       <div className="space-y-8">{renderContent()}</div>
 
       {/* 상세 정보 모달 (isOpen과 isReceived prop만 전달) */}

--- a/app/dashboard/task/_components/TaskPageContainer.tsx
+++ b/app/dashboard/task/_components/TaskPageContainer.tsx
@@ -1,12 +1,8 @@
-'use client';
+"use client"
 
-import { ReactNode } from "react";
+import { ReactNode } from "react"
 
 // 클라이언트 컴포넌트로 변경하여 SSR 문제를 해결
 export default function TaskPageContainer({ children }: { children: ReactNode }) {
-  return (
-    <div className="w-full">
-      {children}
-    </div>
-  );
+  return <div className="w-full min-w-0">{children}</div>
 }

--- a/app/dashboard/task/_components/TaskPageNavTab.tsx
+++ b/app/dashboard/task/_components/TaskPageNavTab.tsx
@@ -1,33 +1,33 @@
-'use client'
+"use client"
 
-import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useSearchParams, useRouter, usePathname } from "next/navigation"
 
 export default function TaskPageNavTab() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const pathname = usePathname()
 
-  const activeTab = (searchParams.get('tab') ?? 'received') as 'received' | 'requested'
+  const activeTab = (searchParams.get("tab") ?? "received") as "received" | "requested"
 
-  const navigate = (tab: 'received' | 'requested') => {
+  const navigate = (tab: "received" | "requested") => {
     const params = new URLSearchParams(searchParams.toString())
-    params.set('tab', tab)
+    params.set("tab", tab)
     // 기존에 id 등 다른 파라미터가 있으면 유지
     router.push(`${pathname}?${params.toString()}`)
   }
 
   return (
-    <div className="p-6 pt-0">
+    <div className="pt-0">
       <div className="tabs tabs-boxed mb-6">
         <button
-          className={`tab ${activeTab === 'received' ? 'tab-active' : ''}`}
-          onClick={() => navigate('received')}
+          className={`tab ${activeTab === "received" ? "tab-active" : ""}`}
+          onClick={() => navigate("received")}
         >
           받은 의뢰
         </button>
         <button
-          className={`tab ${activeTab === 'requested' ? 'tab-active' : ''}`}
-          onClick={() => navigate('requested')}
+          className={`tab ${activeTab === "requested" ? "tab-active" : ""}`}
+          onClick={() => navigate("requested")}
         >
           신청한 의뢰
         </button>

--- a/app/dashboard/task/_components/TaskRow.tsx
+++ b/app/dashboard/task/_components/TaskRow.tsx
@@ -76,7 +76,7 @@ export default function TaskRow({ task, taskType, activeTab, gameImageMap }: Pro
 
   return (
     <div
-      className={`flex items-center justify-between p-4 border-b ${
+      className={`flex flex-wrap items-center justify-between p-4 border-b ${
         taskType === "past" ? "text-gray-400" : ""
       }`}
     >
@@ -173,49 +173,54 @@ export default function TaskRow({ task, taskType, activeTab, gameImageMap }: Pro
       </div>
 
       {!isPast && (
-        <>
+        <div className="flex items-center gap-2 ml-2 max-[660px]:basis-full max-[660px]:justify-end max-[660px]:flex-wrap">
           {isReceived && isScheduled && (
             <>
               <button
-                className="btn btn-primary btn-sm mr-2"
+                className="btn btn-primary btn-sm max-[660px]:btn-xs"
                 onClick={() => handleChangeStatus(task.id, "accepted")}
+                aria-label="수락하기"
               >
                 <Check className="w-4 h-4" />
-                수락하기
+                <span className="hidden sm:inline">수락하기</span>
               </button>
               <button
-                className="btn btn-error btn-sm"
+                className="btn btn-error btn-sm max-[660px]:btn-xs"
                 onClick={() => handleChangeStatus(task.id, "rejected")}
+                aria-label="거절하기"
               >
                 <X className="w-4 h-4" />
-                거절하기
+                <span className="hidden sm:inline">거절하기</span>
               </button>
             </>
           )}
 
           {isReceived && isCurrent && (
             <button
-              className="btn btn-primary btn-sm"
+              className="btn btn-primary btn-sm max-[660px]:btn-xs"
               onClick={() => handleChangeStatus(task.id, "completed")}
+              aria-label="완료하기"
             >
-              완료하기
+              <Check className="w-4 h-4" />
+              <span className="hidden sm:inline">완료하기</span>
             </button>
           )}
 
           {!isReceived && isScheduled && (
             <button
-              className="btn btn-error btn-sm"
+              className="btn btn-error btn-sm max-[660px]:btn-xs"
               onClick={() => handleChangeStatus(task.id, "canceled")}
+              aria-label="취소하기"
             >
               <X className="w-4 h-4" />
-              취소하기
+              <span className="hidden sm:inline">취소하기</span>
             </button>
           )}
 
-          <button className="btn btn-ghost btn-circle btn-sm ml-2">
+          <button className="btn btn-ghost btn-circle btn-sm ml-2" aria-label="메시지 보내기">
             <MessageSquare className="w-4 h-4" />
           </button>
-        </>
+        </div>
       )}
 
       {activeTab === "requested" && taskType === "past" && task.status === "completed" && (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,14 +44,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <PlausibleProvider domain={config.domainName} />
         </head>
       )}
-      <body>
+      <body className="overflow-x-hidden">
         {/* ClientLayout contains all the client wrappers (Crisp chat support, toast messages, tooltips, etc.) */}
         <QueryProvider>
           <ClientLayout>
             <Header />
             <div className="flex">
               <Sidebar />
-              <main className="flex-1 overflow-x-hidden md:ml-64">
+              <main className="min-w-0 flex-1 overflow-x-hidden md:ml-64">
                 {children}
                 <Footer />
               </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <QueryProvider>
           <ClientLayout>
             <Header />
-            <div className="flex">
+            <div className="flex w-full min-w-0">
               <Sidebar />
               <main className="min-w-0 flex-1 overflow-x-hidden md:ml-64">
                 {children}

--- a/ex-README.md
+++ b/ex-README.md
@@ -1,0 +1,105 @@
+![붕마카세표지](https://github.com/user-attachments/assets/6b1e0124-e36d-48be-be38-c741619c59b4)
+
+<h1 align="middle">붕마카세</h1>
+<p align="middle">나만의 붕어빵 아카이브</p>
+<p align="center">
+<img src="https://img.shields.io/badge/version-0.1.0-orange.svg?cacheSeconds=2592000" />
+<a href="https://www.instagram.com/boong_ma" target="_blank"><img src="https://img.shields.io/badge/-instagram-pink?style=square&logo=instagram&logoColor=white" /></a>
+  <a href="https://slashpage.com/bungmakase" target="_blank"><img src="https://img.shields.io/badge/-introduction-FBA518?style=square&logo=slashdot&logoColor=white" /></a>
+</p>
+
+## 🍞 Project Introduction
+
+<p align="middle">전국 붕어빵 정보를 <b>아카이빙</b>하고, <b>나만의 도감을 완성해가는 재미</b>와<br/>
+사용자간 <b>랭킹 경쟁</b>까지 제공하는 붕어빵 특화 플랫폼 
+</p>
+
+<a href="https://bungmakase.vercel.app" target="_blank">🍞 붕마카세 서비스 바로가기</a> <br/>
+<a href="https://slashpage.com/bungmakase" target="_blank">🍞 붕마카세 소개페이지 바로가기 </a> <br/>
+
+<a href="https://github.com/bungmakase/bungmakase_frontend" target="_blank">🍞 붕마카세 프론트엔드 레포지토리</a> <br/>
+<a href="https://github.com/bungmakase/bungmakase_backend" target="_blank">🍞 붕마카세 백엔드 레포지토리</a> <br/>
+
+## 👉 Start
+
+#### 설치
+
+```
+pnpm install
+```
+
+#### 실행
+
+```
+pnpm run dev
+```
+
+## 🏃 Developers
+
+|                                                         FE                                                          |                                                         FE                                                          |
+| :-----------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------: |
+| <img style="width: 150px;" src="https://github.com/user-attachments/assets/1089bb2d-5b8c-4295-a35f-5a301b7e393c" /> | <img style="width: 150px;" src="https://github.com/user-attachments/assets/ea136409-cf5f-4053-982b-6296662ecd52" /> |
+|                                                       김소현                                                        |                                                       김성진                                                        |
+|                                       [@5o-hyun](https://github.com/5o-hyun)                                        |                                       [@muffin9](https://github.com/muffin9)                                        |
+
+## 👨‍💻 Tech Stacks
+
+  <a href="https://skillicons.dev">
+    <img src="https://go-skill-icons.vercel.app/api/icons?i=nextjs,ts,reactquery,tailwind,shadcn,storybook,zustand,pnpm&titles=true"/>
+  </a>
+
+Node v.22.13.0 (LTS)  
+언어/프레임워크 : `typescript` `nextjs@15`  
+UI 라이브러리/프레임워크 : `tailwind` `shadcn/ui` `framer-motion`  
+상태 관리 라이브러리: `zustand` `tanstack@react-query`  
+테스트도구 : `storybook` `vitest`  
+데이터검증 : `zod`  
+패키지매니저 : `pnpm`  
+지도: `kakao maps api`
+
+## 📚 Architecture
+
+root/  
+├── app/ # Next.js 라우팅 처리 (app directory 구조)  
+├── api/ # react-query로 데이터 패칭 관련 파일  
+├── styles/ # 스타일 관련 파일 (글로벌 스타일, CSS 변수)  
+├── components/ # 공통 컴포넌트 모음  
+│ ├── common/ # Footer, Header 등 여러 페이지에서 공통으로 사용하는 컴포넌트  
+│ ├── ui/ # shadcn/ui 명령어로 생성된 UI 컴포넌트  
+├── hooks/ # 재사용 가능한 React 커스텀 훅  
+├── interfaces/ # TypeScript 인터페이스 및 타입 정의 파일  
+├── types/ # interfaces와 비슷하지만, 전역적으로 사용하는 유틸리티 타입, 단순 타입 정의 관리.  
+├── lib/ # 데이터 포멧 관련, 유틸리티 함수, API 통신 모듈  
+├── mocks/ # Mock 데이터 및 관련 설정 파일 (e.g., MSW, JSON mock)  
+├── store/ # 상태 관리와 관련된 모든 파일을 저장.  
+├── constants/ # 프로젝트 전역에서 사용하는 상수 값  
+├── config/ # 프로젝트 설정 관련 파일 (e.g., 환경 변수, 라우팅 설정, DB)
+
+`도메인별로 관심사를 분리`, 유저 마이페이지 관련 도메인이라고 가정했을 때 app-mypage / components-mypage 폴더를 각각 생성하여 코드 작성
+
+vitest 코드는 해보고 싶은 페이지나, 필요한 로직에 자율적으로 작성  
+storybook 코드는 ui test를 할 코드와 동일한 위치에 작성
+
+## 📌 Functional Specification
+
+<img width="991" alt="Image" src="https://github.com/user-attachments/assets/8b3bf594-659a-46ae-b0d6-31144bc5c2a5" />
+
+## 🗳️ API Specification
+
+[API DOCS](http://211.188.61.117:8080/swagger-ui/index.html)
+
+## 💡 Intro
+
+![1](https://github.com/user-attachments/assets/5e169517-9a94-46c2-8ff3-726cff51b7f9)
+![2](https://github.com/user-attachments/assets/33004387-5e0c-48f0-b204-1dabbc0ea9ef)
+![3](https://github.com/user-attachments/assets/d0b925d1-b68e-46f8-95dc-f7bb7ce81b2e)
+
+## 💡 Functions
+
+![4](https://github.com/user-attachments/assets/463c58de-b756-4e3e-814c-2394c09b8531)
+![5](https://github.com/user-attachments/assets/be8a99a0-7d66-4a6b-ac9b-a4f95452543a)
+![6](https://github.com/user-attachments/assets/0fa3b7c1-7f55-4625-a268-f61de669aafc)
+
+## 💫 License
+
+Copyright © 2025 bungmakase-frontend


### PR DESCRIPTION
최소폭 전파 차단: 상위 flex 컨테이너와 주요 섹션 래퍼에 min-w-0 지정. 이로써 자식의 min-content width가 상위 폭을 강제하지 않음.
버튼군/액션 영역: 별도 래퍼로 묶고 반응형 기준으로 basis-full + flex-wrap + btn-xs 적용, 텍스트 라벨은 sm 이상에서만 노출해 폭 점유 최소화.
테이블: w-full table-auto + 래퍼 overflow-x-auto로 과도한 열 폭 요구 시 내부 스크롤만 발생하도록 격리.
타이포/화이트스페이스: text-xs sm:text-sm, whitespace-nowrap로 정보 밀도와 줄바꿈 제어. 숫자/뱃지 등 UI 크기를 rem 기반으로 하향.
날짜 포맷: utils/date/formatRelativeFromNow 사용으로 “N시간 전/일 전” 표기, 작은 화면에서 절대 날짜의 길이로 인한 줄깨짐 방지.
옵션 분기: TokenHistoryListMobile를 도입해 sm 미만 환경에서 카드 리스트 전환 가능(현재는 테이블 유지 상태).