### PR TITLE
[refactor] : SearchBar 컴포넌트 분리 및 내부 로직 수정

### DIFF
--- a/app/dashboard/_components/header/SearchBar.tsx
+++ b/app/dashboard/_components/header/SearchBar.tsx
@@ -1,190 +1,203 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
-import { Loader2, Search } from "lucide-react"
-import Image from "next/image"
-import Link from "next/link"
+import { useCallback, useMemo, useRef, useState } from "react"
+import { Loader2, Search as SearchIcon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useQueryClient } from "@tanstack/react-query"
-import { DEFAULT_AVATAR_SRC } from "@/constants/image"
+
 import { useUserSearchLive } from "@/hooks/api/profile/useUserSearchLive"
-import debounce from "lodash/debounce"
 import { queryKeys } from "@/constants/queryKeys"
 
+import useDebouncedCallback from "../../_hooks/useDebounceCallback"
+import SearchBarDropdown from "./searchBar/SearchBarDropdown"
+import type { UserSearchResult, UseUserSearchLiveReturn } from "./searchBar/types"
+
+/* ───────────────── 타입은 ./searchBar/types 로 분리 ───────────────── */
+
+/* ───────────────── 메인 컴포넌트 ─────────────────
+   목표:
+   - 불필요한 useEffect 제거
+   - 파일 파편화 최소화(프레젠테이셔널은 동일 파일 하단에 배치)
+   - IME 조합 중이라도 2자 이상이면 검색 트리거
+   - 로딩 중일 때는 글자 수 미만이어도 드롭다운 표시
+----------------------------------------------------------------------------- */
 export default function SearchBar() {
-  const [isSearchOpen, setIsSearchOpen] = useState<boolean>(false)
+  const MIN = 2 // 최소 검색 길이(UX/성능 밸런스에 맞게 조절)
+
+  // UI/상태
+  const [isOpen, setIsOpen] = useState(false) // 검색창 열림/닫힘
+  const [value, setValue] = useState("") // 입력값
+  const [activeIndex, setActiveIndex] = useState(-1) // 키보드 포커스용 인덱스
+
+  // DOM ref
   const containerRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
-  const latestSearchRef = useRef<(v: string) => void>(() => {})
-  const [len, setLen] = useState(0)
-  const [activeIndex, setActiveIndex] = useState<number>(-1)
+
+  // 라우팅/쿼리
   const router = useRouter()
   const qc = useQueryClient()
 
-  // 수동 refetch 기반 라이브 검색 훅(내부 상태 보유 X, 입력값은 ref로 관리)
-  const { data, isFetching, isError, search } = useUserSearchLive(8)
-  // 최신 search 콜백을 ref에 유지해 디바운스 인스턴스가 재생성되지 않도록 함
-  useEffect(() => {
-    latestSearchRef.current = search
-  }, [search])
-  const items = data?.items ?? []
+  // 라이브 검색 훅 (주의: 내부에서 AbortSignal을 지원하면 cancel로 실제 네트워크 abort 가능)
+  const { data, isFetching, isError, search, cancel } = useUserSearchLive(
+    8,
+  ) as unknown as UseUserSearchLiveReturn
 
-  // 입력 이벤트에 바로 연결 가능한 디바운스 함수(1회 생성)
-  const debouncedSearch = useMemo(
-    () => debounce((v: string) => latestSearchRef.current(v), 300),
-    [],
-  )
-  useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch])
+  /* ✅ items 메모이즈 (경고 해결 포인트)
+     - data?.items ?? [] 로직은 매 렌더마다 새로운 빈 배열을 만들 수 있음
+     - useMemo로 참조 안정화하여 useCallback 의존성 변동을 억제
+  */
+  const items = useMemo<UserSearchResult[]>(() => (data?.items ? data.items : []), [data?.items])
 
-  const handleBlur: React.FocusEventHandler<HTMLDivElement> = (e) => {
-    const next = e.relatedTarget as Node | null
-    if (next && containerRef.current?.contains(next)) return
-    // 남아있는 대기 호출 취소
-    debouncedSearch.cancel()
-    // 인플라이트 쿼리 취소
+  // 엔터 없이도 드롭다운 노출 + 로딩 중이면 글자 수 미만이어도 드롭다운 표시
+  const showDropdown = isOpen && (value.trim().length >= MIN || isFetching)
+
+  // 디바운스된 검색: 2자 이상일 때만 질의 전송
+  const { debounced, cancel: cancelDebounce } = useDebouncedCallback((q: string) => {
+    if (q.trim().length >= MIN) search(q)
+  }, 300)
+
+  // 하드 취소: 디바운스 타이머 + 네트워크(지원 시) + 쿼리 취소(fallback)
+  const hardCancel = useCallback(() => {
+    cancelDebounce()
+    cancel?.()
     void qc.cancelQueries({ queryKey: queryKeys.search.users("live") })
-    setIsSearchOpen(false)
+  }, [cancel, cancelDebounce, qc])
+
+  // 유효한 activeIndex로 보정 (감시형 effect 대신 "사용 시점"에서만 보정)
+  const getValidActiveIndex = useCallback(
+    (idx: number) => {
+      if (!showDropdown) return -1
+      if (items.length === 0) return -1
+      if (idx < -1) return -1
+      if (idx >= items.length) return items.length - 1
+      return idx
+    },
+    [showDropdown, items.length], // 길이만 의존해도 충분
+  )
+
+  // 포커스 아웃 시 전체 정리(검색 취소/값 초기화)
+  const onBlur: React.FocusEventHandler<HTMLDivElement> = (e) => {
+    const next = e.relatedTarget as Node | null
+    if (next && containerRef.current?.contains(next)) return // 컨테이너 내부 포커스 이동은 유지
+    hardCancel()
+    setIsOpen(false)
+    setValue("")
+    setActiveIndex(-1)
   }
 
-  // 선택 이동 시 가시 영역으로 스크롤
-  useEffect(() => {
-    if (activeIndex < 0) return
-    const id = `search-users-option-${activeIndex}`
-    document.getElementById(id)?.scrollIntoView({ block: "nearest" })
-  }, [activeIndex])
+  // 입력 변경: 2자 이상이면 즉시 디바운스 검색 트리거
+  const onChange = useCallback(
+    (next: string) => {
+      setValue(next)
+      setActiveIndex(-1) // 입력이 바뀌면 포커스 초기화
+      if (next.trim().length >= MIN) debounced(next)
+    },
+    [debounced],
+  )
 
-  // 결과 변화/표시 조건 변화에 따라 activeIndex를 안전하게 보정
-  useEffect(() => {
-    if (len < 2) {
-      if (activeIndex !== -1) setActiveIndex(-1)
-      return
-    }
-    if (items.length === 0) {
-      if (activeIndex !== -1) setActiveIndex(-1)
-      return
-    }
-    if (activeIndex >= items.length) {
-      setActiveIndex(items.length - 1)
-    }
-  }, [items.length, len, activeIndex])
+  // 키보드 내비게이션/액션
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        // ESC: 전체 초기화
+        hardCancel()
+        setIsOpen(false)
+        setValue("")
+        setActiveIndex(-1)
+      } else if (e.key === "ArrowDown") {
+        // ↓: 다음 항목
+        e.preventDefault()
+        const next = getValidActiveIndex(activeIndex + 1)
+        setActiveIndex(next)
+        if (next >= 0) {
+          const id = `search-users-option-${next}`
+          document.getElementById(id)?.scrollIntoView({ block: "nearest" })
+        }
+      } else if (e.key === "ArrowUp") {
+        // ↑: 이전 항목
+        e.preventDefault()
+        const next = getValidActiveIndex(activeIndex - 1)
+        setActiveIndex(next)
+        if (next >= 0) {
+          const id = `search-users-option-${next}`
+          document.getElementById(id)?.scrollIntoView({ block: "nearest" })
+        }
+      } else if (e.key === "Enter") {
+        // Enter: 활성 항목 이동
+        if (activeIndex >= 0 && items[activeIndex]) {
+          const to = `/profile/${items[activeIndex].public_id}`
+          hardCancel()
+          setIsOpen(false)
+          setValue("")
+          setActiveIndex(-1)
+          router.push(to)
+        }
+      } else if (e.key === "Home") {
+        // Home: 첫 항목
+        e.preventDefault()
+        const next = getValidActiveIndex(0)
+        setActiveIndex(next)
+      } else if (e.key === "End") {
+        // End: 마지막 항목
+        e.preventDefault()
+        const next = getValidActiveIndex(items.length - 1)
+        setActiveIndex(next)
+      }
+    },
+    [activeIndex, getValidActiveIndex, hardCancel, items, router],
+  )
 
   return (
-    <div ref={containerRef} className="relative" onBlur={handleBlur}>
-      {isSearchOpen ? (
+    <div ref={containerRef} className="relative" onBlur={onBlur}>
+      {isOpen ? (
         <div className="flex items-center gap-2 mr-4">
+          {/* 입력 영역 */}
           <div className="relative">
             <input
-              type="text"
               ref={inputRef}
-              onChange={(e) => {
-                const v = e.target.value
-                setLen(v.trim().length) // 드롭다운 표시 상태만 담당
-                debouncedSearch(v) // 네트워크 요청은 디바운스
-                setActiveIndex(-1) // 입력이 바뀌면 선택 초기화
-              }}
+              type="text"
+              value={value}
+              onFocus={() => setIsOpen(true)} // 포커스 시 열림 유지
+              onChange={(e) => onChange(e.target.value)}
+              onKeyDown={onKeyDown}
               placeholder="닉네임 또는 사용자명을 입력하세요(2자 이상)"
               className="input input-ghost w-full max-w-xs h-8 text-sm pr-7"
               autoFocus
+              // ARIA: 콤보박스 + 리스트박스 관계
               role="combobox"
-              aria-expanded={isSearchOpen}
-              aria-controls="search-users-listbox"
+              aria-haspopup="listbox"
+              aria-expanded={showDropdown}
+              aria-controls={showDropdown ? "search-users-listbox" : undefined}
               aria-activedescendant={
                 activeIndex >= 0 ? `search-users-option-${activeIndex}` : undefined
               }
               aria-autocomplete="list"
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  debouncedSearch.cancel()
-                  void qc.cancelQueries({ queryKey: queryKeys.search.users("live") })
-                  setIsSearchOpen(false)
-                } else if (e.key === "ArrowDown") {
-                  e.preventDefault()
-                  setActiveIndex((prev) => Math.min(items.length - 1, prev + 1))
-                } else if (e.key === "ArrowUp") {
-                  e.preventDefault()
-                  setActiveIndex((prev) => Math.max(-1, prev - 1))
-                } else if (e.key === "Enter") {
-                  if (activeIndex >= 0 && items[activeIndex]) {
-                    const to = `/profile/${items[activeIndex].public_id}`
-                    debouncedSearch.cancel()
-                    void qc.cancelQueries({ queryKey: queryKeys.search.users("live") })
-                    setIsSearchOpen(false)
-                    router.push(to)
-                  }
-                }
-              }}
             />
+            {/* 입력 우측 아이콘: 로딩 중이면 스피너 */}
             <div className="pointer-events-none absolute right-2 top-1.5 text-base-content/60">
               {isFetching ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
               ) : (
-                <Search className="w-4 h-4" />
+                <SearchIcon className="w-4 h-4" />
               )}
             </div>
           </div>
 
-          {/* 드롭다운 */}
-          {len >= 2 && (
-            <div className="absolute right-0 top-[110%] z-50 w-[22rem] max-w-[90vw] rounded-lg border bg-base-100 shadow-lg">
-              <ul id="search-users-listbox" role="listbox" className="max-h-80 overflow-auto py-2">
-                {isFetching && items.length === 0 ? (
-                  <li className="px-4 py-3 text-sm text-base-content/60">검색 중…</li>
-                ) : isError ? (
-                  <li className="px-4 py-3 text-sm text-error">검색 중 오류가 발생했습니다</li>
-                ) : items.length === 0 ? (
-                  <li className="px-4 py-3 text-sm text-base-content/60">
-                    일치하는 사용자가 없습니다
-                  </li>
-                ) : (
-                  items.map((u, idx) => (
-                    <li
-                      key={u.profile_id}
-                      id={`search-users-option-${idx}`}
-                      role="option"
-                      aria-selected={activeIndex === idx}
-                      className="px-2"
-                      onMouseEnter={() => setActiveIndex(idx)}
-                    >
-                      <Link
-                        href={`/profile/${u.public_id}`}
-                        className={
-                          `flex items-center gap-3 rounded-md px-2 py-2 focus:outline-none ` +
-                          (activeIndex === idx ? "bg-base-200" : "hover:bg-base-200")
-                        }
-                      >
-                        <div className="relative w-10 h-10 rounded-full overflow-hidden shrink-0">
-                          <Image
-                            src={u.profile_circle_img || DEFAULT_AVATAR_SRC}
-                            alt={u.username ?? u.nickname ?? "profile"}
-                            fill
-                            sizes="40px"
-                            className="object-cover"
-                          />
-                          <span
-                            className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-base-100"
-                            style={{ backgroundColor: u.is_online ? "#0EA5E9" : "#9CA3AF" }}
-                            aria-label={u.is_online ? "온라인" : "오프라인"}
-                          />
-                        </div>
-                        <div className="min-w-0">
-                          <div className="text-sm font-semibold truncate">
-                            {u.username ?? u.name ?? "-"}
-                          </div>
-                          <div className="text-xs text-base-content/60 truncate">
-                            {u.nickname ?? "닉네임 없음"}
-                          </div>
-                        </div>
-                      </Link>
-                    </li>
-                  ))
-                )}
-              </ul>
-            </div>
+          {/* 드롭다운: 로딩 중에도 열어서 '검색 중…' 상태를 표시 */}
+          {showDropdown && (
+            <SearchBarDropdown
+              items={items}
+              isFetching={isFetching}
+              isError={isError}
+              activeIndex={activeIndex}
+              onItemHover={(i) => setActiveIndex(getValidActiveIndex(i))}
+            />
           )}
         </div>
       ) : (
-        <button className="btn btn-ghost btn-circle" onClick={() => setIsSearchOpen(true)}>
-          <Search className="w-5 h-5" />
+        // 닫힘 상태: 아이콘 버튼
+        <button className="btn btn-ghost btn-circle" onClick={() => setIsOpen(true)}>
+          <SearchIcon className="w-5 h-5" />
         </button>
       )}
     </div>

--- a/app/dashboard/_components/header/searchBar/ResultItem.tsx
+++ b/app/dashboard/_components/header/searchBar/ResultItem.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import Link from "next/link"
+import Image from "next/image"
+import { DEFAULT_AVATAR_SRC } from "@/constants/image"
+
+import { UserSearchResult } from "./types"
+
+export default function ResultItem({
+  user,
+  index,
+  isActive,
+  onHover,
+}: {
+  user: UserSearchResult
+  index: number
+  isActive: boolean
+  onHover: () => void
+}) {
+  return (
+    <li
+      id={`search-users-option-${index}`}
+      role="option"
+      aria-selected={isActive}
+      className="px-2"
+      onMouseEnter={onHover}
+    >
+      <Link
+        href={`/profile/${user.public_id}`}
+        className={`flex items-center gap-3 rounded-md px-2 py-2 focus:outline-none ${
+          isActive ? "bg-base-200" : "hover:bg-base-200"
+        }`}
+      >
+        <div className="relative w-10 h-10 rounded-full overflow-hidden shrink-0">
+          <Image
+            src={user.profile_circle_img || DEFAULT_AVATAR_SRC}
+            alt={user.username ?? user.nickname ?? "profile"}
+            fill
+            sizes="40px"
+            className="object-cover"
+          />
+          <span
+            className="absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-base-100"
+            style={{ backgroundColor: user.is_online ? "#0EA5E9" : "#9CA3AF" }}
+            aria-label={user.is_online ? "온라인" : "오프라인"}
+          />
+        </div>
+        <div className="min-w-0">
+          <div className="text-sm font-semibold truncate">{user.username ?? user.name ?? "-"}</div>
+          <div className="text-xs text-base-content/60 truncate">
+            {user.nickname ?? "닉네임 없음"}
+          </div>
+        </div>
+      </Link>
+    </li>
+  )
+}

--- a/app/dashboard/_components/header/searchBar/SearchBarDropdown.tsx
+++ b/app/dashboard/_components/header/searchBar/SearchBarDropdown.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import ResultItem from "./ResultItem"
+import type { UserSearchResult } from "./types"
+
+export default function SearchBarDropdown({
+  items,
+  isFetching,
+  isError,
+  activeIndex,
+  onItemHover,
+}: {
+  items: UserSearchResult[]
+  isFetching: boolean
+  isError: boolean
+  activeIndex: number
+  onItemHover: (i: number) => void
+}) {
+  return (
+    <div className="absolute right-0 top-[110%] z-50 w-[22rem] max-w-[90vw] rounded-lg border bg-base-100 shadow-lg">
+      <ul
+        id="search-users-listbox"
+        role="listbox"
+        aria-label="사용자 검색 결과"
+        aria-live="polite"
+        aria-busy={isFetching || undefined}
+        className="max-h-80 overflow-auto py-2"
+      >
+        {/* 로딩 행: 항상 상단 표시(이전 결과와 동시 표출 가능) */}
+        {isFetching && <li className="px-4 py-3 text-sm text-base-content/60">검색 중…</li>}
+
+        {/* 에러 상태 */}
+        {!isFetching && isError && (
+          <li className="px-4 py-3 text-sm text-error">검색 중 오류가 발생했습니다</li>
+        )}
+
+        {/* 결과/빈 상태 */}
+        {!isError && items.length === 0 && !isFetching ? (
+          <li className="px-4 py-3 text-sm text-base-content/60">일치하는 사용자가 없습니다</li>
+        ) : (
+          items.map((u, idx) => (
+            <ResultItem
+              key={u.profile_id}
+              user={u}
+              index={idx}
+              isActive={activeIndex === idx}
+              onHover={() => onItemHover(idx)}
+            />
+          ))
+        )}
+      </ul>
+    </div>
+  )
+}

--- a/app/dashboard/_components/header/searchBar/types.ts
+++ b/app/dashboard/_components/header/searchBar/types.ts
@@ -1,0 +1,19 @@
+// 검색바 관련 타입 모음 (클라이언트/프레젠테이셔널 간 공유)
+
+export type UserSearchResult = {
+  profile_id: string
+  public_id: string
+  username?: string
+  name?: string
+  nickname?: string
+  profile_circle_img?: string
+  is_online: boolean
+}
+
+export type UseUserSearchLiveReturn = {
+  data?: { items: UserSearchResult[] }
+  isFetching: boolean
+  isError: boolean
+  search: (q: string) => void
+  cancel?: () => void // 훅이 AbortController 기반 취소를 지원하는 경우
+}

--- a/app/dashboard/_hooks/useDebounceCallback.ts
+++ b/app/dashboard/_hooks/useDebounceCallback.ts
@@ -1,0 +1,33 @@
+"use client"
+
+import { useCallback, useRef } from "react"
+
+/* ───────────────── Debounced callback (lodash 제거, 내부에서 정리까지) ─────────────────
+   - 컴포넌트 바깥에서 디바운스 상태를 관리하므로 useEffect 없이도 클린업이 보장됩니다.
+   - 동일 인스턴스 보장을 위해 fn을 ref에 유지하고, 타이머도 ref로 관리합니다.
+----------------------------------------------------------------------------- */
+export default function useDebouncedCallback<T extends (...args: any[]) => void>(
+  fn: T,
+  delay = 300,
+) {
+  const fnRef = useRef(fn)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  fnRef.current = fn
+
+  const debounced = useCallback(
+    (...args: Parameters<T>) => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => fnRef.current(...args), delay)
+    },
+    [delay],
+  )
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  return { debounced, cancel }
+}


### PR DESCRIPTION
WHY
- SearchBar 내부에 타입/프레젠테이셔널이 혼재되어 유지보수성과 재사용성이 낮았음
- 컴포넌트 역할 분리로 가독성/테스트 용이성/재사용성 향상 필요

WHAT
- SearchBar.tsx: 내부 타입/Dropdown/ResultItem 제거, 외부 컴포넌트/타입 임포트로 대체
- searchBar/SearchBarDropdown.tsx: 드롭다운 프레젠테이셔널 분리(ARIA/로딩/에러/빈 상태 포함)
- searchBar/ResultItem.tsx: 클라이언트 컴포넌트 지정 및 타입 의존성 분리(./types)
- searchBar/types.ts: UserSearchResult/UseUserSearchLiveReturn 타입 분리
- _hooks/useDebounceCallback.ts: 입력 디바운스 공용 훅 추가

TEST
- 2자 이상 입력 시 300ms 디바운스 검색 트리거 확인
- 로딩/에러/빈 상태 메시지 정상 노출 확인
- 키보드 내비(↑/↓/Home/End/Enter/ESC) 및 ARIA 속성 유지 확인
- ESC/포커스 아웃 시 하드 취소(디바운스/네트워크/쿼리 취소) 및 상태 초기화 확인