### PR TITLE
[refactor] : profile/[id] SSR prefetch 단일 I/O 및 페이지 레벨 QuerySectionBoundary 적용

### DIFF
--- a/app/profile/[id]/page.tsx
+++ b/app/profile/[id]/page.tsx
@@ -1,37 +1,29 @@
-import { notFound } from "next/navigation"
+import QuerySectionBoundary from "@/components/query/QuerySectionBoundary"
+import { queryKeys } from "@/constants/queryKeys"
 
-import { svcCheckProfileExists } from "@/app/apis/service/profile/profile.service.server"
-
-import ProfileMainBoundary from "../_components/ProfileMainBoundary"
-import ProfileHeaderBoundary from "../_components/ProfileHeaderBoundary"
 import ProfilePageContainer from "../_components/ProfilePageContaier"
+import ProfileHeader from "../_components/ProfileHeader"
+import ProfileMainContent from "../_components/ProfileMainContent"
 
 interface ProfilePageProps {
   params: Promise<{ id: string }>
-}
-
-// 서버 컴포넌트에서 초기 데이터 로드 (404 처리용)
-async function checkProfileExists(profileId: string): Promise<boolean> {
-  return svcCheckProfileExists(profileId)
 }
 
 export default async function ProfilePage({ params }: ProfilePageProps) {
   const resolvedParams = await params
   const profileId = resolvedParams.id
 
-  // 서버 레벨에서 프로필 존재 유무 확인 후 404 처리
-  const profileExists = await checkProfileExists(profileId)
-  if (!profileExists) {
-    notFound() // 프로필 없으면 404 페이지 표시
-  }
-
   return (
     <ProfilePageContainer profileId={profileId}>
       {/* 1. 프로필 헤더 */}
-      <ProfileHeaderBoundary profileId={profileId} />
+      <QuerySectionBoundary keys={queryKeys.profile.publicById(Number(profileId))}>
+        <ProfileHeader profileId={profileId} />
+      </QuerySectionBoundary>
 
       {/* 2. 메인 컨텐츠 (탭 네비게이션 및 컨텐츠 포함) */}
-      <ProfileMainBoundary profileId={profileId} />
+      <QuerySectionBoundary keys={queryKeys.profile.publicById(Number(profileId))}>
+        <ProfileMainContent profileId={profileId} />
+      </QuerySectionBoundary>
     </ProfilePageContainer>
   )
 }

--- a/app/profile/_components/ProfilePageContaier.tsx
+++ b/app/profile/_components/ProfilePageContaier.tsx
@@ -1,41 +1,40 @@
-import { ReactNode } from 'react';
-import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { type ReactNode } from "react"
+import { notFound } from "next/navigation"
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query"
 
-import { PrefetchedProfileData } from '@/app/profile/_types/profile.types';
-import { svcGetPublicProfile } from '@/app/apis/service/profile/profile.service.server';
-import { queryKeys } from '@/constants/queryKeys';
+import { queryKeys } from "@/constants/queryKeys"
+import { svcGetPublicProfile } from "@/app/apis/service/profile/profile.service.server"
+import type { PrefetchedProfileData } from "@/app/profile/_types/profile.types"
 
 // 컴포넌트 Props 타입 정의
 interface ProfilePageContainerProps {
-  profileId: string; // 조회할 프로필의 ID
-  children: ReactNode;
+  profileId: string // 조회할 프로필의 ID
+  children: ReactNode
 }
 
 export default async function ProfilePageContainer({
   profileId,
   children,
 }: ProfilePageContainerProps) {
-  const queryClient = new QueryClient();
-  const numericProfileId = Number(profileId);
-  const key = queryKeys.profile.publicById(numericProfileId);
+  const queryClient = new QueryClient()
+  const numericProfileId = Number(profileId)
+  if (!Number.isFinite(numericProfileId)) {
+    notFound()
+  }
+  const key = queryKeys.profile.publicById(numericProfileId)
 
-  await queryClient.prefetchQuery<PrefetchedProfileData | null>({
-    queryKey: key,
-    queryFn: async () => {
-      if (!Number.isFinite(numericProfileId)) return null;
-      return svcGetPublicProfile(numericProfileId);
-    },
-    // 필요시 staleTime 등 옵션 추가
-  });
+  // 서버에서 단일 I/O로 데이터 조회 및 404 판정
+  const data = await svcGetPublicProfile(numericProfileId)
+  if (!data) {
+    notFound()
+  }
+  queryClient.setQueryData<PrefetchedProfileData>(key, data)
 
-  const dehydratedState = dehydrate(queryClient);
+  const dehydratedState = dehydrate(queryClient)
 
   return (
     <main className="min-h-screen bg-base-100">
-      <HydrationBoundary state={dehydratedState}>
-        {children}
-      </HydrationBoundary>
+      <HydrationBoundary state={dehydratedState}>{children}</HydrationBoundary>
     </main>
-  );
+  )
 }
-


### PR DESCRIPTION
WHY
- 중복 I/O 제거로 TTFB 감소
- 페이지 선언성 유지, 섹션 경계 단순화 및 하이드레이션 즉시 렌더 보장

WHAT
- app/profile/_components/ProfilePageContaier.tsx: svcGetPublicProfile 단일 호출, notFound() 조기 분기, QueryClient.setQueryData → dehydrate → HydrationBoundary. import 정리(type-only 포함)
- app/profile/[id]/page.tsx: ProfileHeaderBoundary/ProfileMainBoundary 제거, QuerySectionBoundary(keys=queryKeys.profile.publicById(Number(profileId)))로 Header/Main 감싸도록 변경

CHECK
- 훅 staleTime=300_000 유지로 SSR 직후 불필요한 refetch 방지
- 쿼리 키 일치로 하이드레이션 캐시 히트 확인