### PR TITLE
[refactor] : profile 레이어 분리 및 login 플로우 SSOT 통일

### DIFF
--- a/app/apis/repository/category/gamesRepository.ts
+++ b/app/apis/repository/category/gamesRepository.ts
@@ -1,4 +1,4 @@
-"use server"
+import "server-only"
 import { getServerSupabase } from "@/app/apis/base"
 
 export async function listGames(offset: number, limit: number) {

--- a/app/apis/repository/user/user.repository.server.ts
+++ b/app/apis/repository/user/user.repository.server.ts
@@ -1,0 +1,25 @@
+import "server-only"
+import { createServerClientComponent } from "@/supabase/functions/server"
+import type { UsersRow } from "@/types/database.table.types"
+
+// users 테이블 단일 조회(없음은 null로 표준화)
+type UserMinimalProjection = Pick<UsersRow, "id" | "name" | "profile_circle_img" | "is_online">
+
+export async function repoGetUserMinimalById(
+  userId: string | null | undefined,
+): Promise<{ data: UserMinimalProjection | null; error: Error | null }> {
+  // userId가 null/undefined/빈 문자열인 경우: 정상값(null)로 표준화하여 상위에서 404 처리하도록 위임
+  if (typeof userId !== "string" || userId.trim() === "") {
+    return { data: null, error: null }
+  }
+
+  const supabase = await createServerClientComponent()
+  const { data, error } = await supabase
+    .from("users")
+    .select("id, name, profile_circle_img, is_online")
+    .eq("id", userId)
+    .maybeSingle()
+
+  if (error) return { data: null, error: error as Error }
+  return { data: (data as UserMinimalProjection) ?? null, error: null }
+}

--- a/app/apis/service/profile/profile.service.server.ts
+++ b/app/apis/service/profile/profile.service.server.ts
@@ -1,39 +1,36 @@
 import "server-only"
-import {
-  repoGetProfileUserIdByPublicId,
-  repoGetPublicProfile,
-} from "@/app/apis/repository/profile/profile.repository.server"
+import { repoGetPublicProfile } from "@/app/apis/repository/profile/profile.repository.server"
+import { repoGetUserMinimalById } from "@/app/apis/repository/user/user.repository.server"
 import type { PrefetchedProfileData } from "@/app/profile/_types/profile.types"
-import type { AppError } from "@/libs/api/errors"
-
-export async function svcCheckProfileExists(profileId: string): Promise<boolean> {
-  const numericProfileId = Number(profileId)
-  if (!Number.isFinite(numericProfileId)) return false
-
-  const { userId } = await repoGetProfileUserIdByPublicId(numericProfileId)
-  return !!userId
-}
+import { wrapService } from "@/app/apis/base/errors"
 
 export async function svcGetPublicProfile(publicId: number): Promise<PrefetchedProfileData | null> {
-  if (!Number.isFinite(publicId)) return null
-  const { data, error } = await repoGetPublicProfile(publicId)
+  return wrapService("profile.svcGetPublicProfile", async () => {
+    if (!Number.isFinite(publicId)) return null
 
-  if (error) {
-    // Supabase PostgrestError 코드(PGRST116: single()에서 0 rows) 또는 메시지 기반 Not Found 판정
-    const raw = error as { code?: unknown; message?: unknown }
-    const code = typeof raw.code === "string" ? raw.code : undefined
-    const message: string = typeof raw.message === "string" ? raw.message : String(error)
-    const isNotFound = code === "PGRST116" || /not found/i.test(message)
+    const { data: profileInfo, error: profileErr } = await repoGetPublicProfile(publicId)
+    if (profileErr) throw profileErr
+    if (!profileInfo) return null
 
-    if (isNotFound) return null
+    const { data: userInfo, error: userErr } = await repoGetUserMinimalById(profileInfo.user_id)
+    if (userErr) throw userErr
+    if (!userInfo) return null
 
-    const appError = new Error(
-      "서버에서 프로필 정보를 불러오는 중 오류가 발생했습니다.",
-    ) as AppError
-    appError.status = 500
-    appError.details = error
-    throw appError
-  }
+    const merged: PrefetchedProfileData = {
+      id: userInfo.id,
+      name: userInfo.name,
+      profile_circle_img: userInfo.profile_circle_img,
+      is_online: userInfo.is_online,
+      user_id: profileInfo.user_id,
+      nickname: profileInfo.nickname,
+      follower_count: profileInfo.follower_count,
+      description: profileInfo.description,
+      selected_tags: profileInfo.selected_tags,
+      youtube_urls: profileInfo.youtube_urls,
+      selected_games: profileInfo.selected_games,
+      public_id: publicId,
+    }
 
-  return data ?? null
+    return merged
+  })
 }

--- a/app/login/_components/LoginPageContainer.tsx
+++ b/app/login/_components/LoginPageContainer.tsx
@@ -33,7 +33,7 @@ export default function LoginPageContainer({ nextParam }: Props) {
   const handleKakaoLogin: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault()
     setIsLoading(true)
-    void loginWithKakao(nextParam).catch((error) => {
+    void loginWithKakao().catch((error) => {
       console.error(error)
       toast.error("로그인 중 오류가 발생했습니다.")
       setIsLoading(false)
@@ -43,7 +43,7 @@ export default function LoginPageContainer({ nextParam }: Props) {
   const handleGoogleLogin: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault()
     setIsGoogleLoading(true)
-    void loginWithGoogle(nextParam).catch((error) => {
+    void loginWithGoogle().catch((error) => {
       console.error(error)
       toast.error("구글 로그인 중 오류가 발생했습니다.")
       setIsGoogleLoading(false)

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next"
+
+function stripTrailingSlash(url: string) {
+  return url.replace(/\/+$/, "")
+}
+
+export default function robots(): MetadataRoute.Robots {
+  const raw = process.env.NEXT_PUBLIC_APP_URL ?? "https://example.com"
+  const baseUrl = stripTrailingSlash(raw)
+  const isProd = process.env.VERCEL_ENV === "production" || process.env.NODE_ENV === "production"
+
+  // 프리뷰/스테이징은 색인 금지, 프로덕션만 허용
+  const rules = isProd
+    ? [
+        {
+          userAgent: "*",
+          allow: "/",
+          disallow: [
+            "/api/", // API 경로 색인 금지
+            "/dashboard/", // 인증 필요한 내부 화면 차단
+            "/_next/", // Next 내부 자원
+          ],
+        },
+      ]
+    : [{ userAgent: "*", disallow: "/" }]
+
+  return {
+    rules,
+    sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from "next"
+
+function stripTrailingSlash(url: string) {
+  return url.replace(/\/+$/, "")
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const raw = process.env.NEXT_PUBLIC_APP_URL ?? "https://example.com"
+  const baseUrl = stripTrailingSlash(raw)
+  const now = new Date()
+
+  // 1) 정적 경로: 홈/카테고리/로그인 등 공개 페이지 위주
+  const staticRoutes: MetadataRoute.Sitemap = ["", "/category", "/login"].map((path) => ({
+    url: `${baseUrl}${path}`,
+    lastModified: now,
+    changeFrequency: "weekly",
+    priority: path === "" ? 1 : 0.7,
+  }))
+
+  // 2) 동적 경로(예: 프로필, 게임 상세 등)
+  // NOTE: 규모가 커지면 sitemap index로 분할 필요
+  // TODO(feat/seo): 서버 전용 Supabase 클라이언트를 사용해 공개 프로필/카테고리 id 목록을 조회
+  // const profiles = await getPublicProfileIds() // 예: [1, 2, 3]
+  // const profileEntries: MetadataRoute.Sitemap = profiles.map((id) => ({
+  //   url: `${baseUrl}/profile/${id}`,
+  //   lastModified: now,
+  //   changeFrequency: "daily",
+  //   priority: 0.6,
+  // }))
+
+  return [
+    ...staticRoutes,
+    // ...profileEntries,
+  ]
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
 
+import { toSafeNextOrDefault } from "@/libs/url/safeNext"
+
 const protectedPaths = ["/dashboard"]
 const authPaths = ["/login"]
 
@@ -33,21 +35,67 @@ export async function middleware(req: NextRequest) {
     const isLoggedIn = !!user
 
     if (isProtectedPath && !isLoggedIn) {
-      // 보호된 페이지 접근 시 미로그인 → 로그인 페이지로 이동 (원래 목적지로 돌아오도록 next 포함)
-      const next = encodeURIComponent(req.nextUrl.pathname + req.nextUrl.search)
-      return NextResponse.redirect(new URL(`/login?next=${next}`, req.url))
+      // 보호된 페이지 접근 시 미로그인 → 로그인 페이지로 이동
+      // 안전한 내부 경로만 허용하여 쿠키(return_to) + 쿼리(next)로 모두 보존
+      const rawNext = req.nextUrl.pathname + req.nextUrl.search
+      const safeNext = toSafeNextOrDefault(rawNext)
+      const redirectUrl = new URL(`/login?next=${encodeURIComponent(safeNext)}`, req.url)
+      const redirectRes = NextResponse.redirect(redirectUrl)
+      // 콜백에서 동일 origin으로 안전 복귀하도록 쿠키에 보존
+      redirectRes.cookies.set("return_to", safeNext, {
+        path: "/",
+        maxAge: 600, // 10분
+        sameSite: "lax",
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+      })
+      return redirectRes
     }
 
     if (isAuthPath && isLoggedIn) {
-      // 로그인 페이지 접근 시 이미 로그인된 사용자 → 대시보드로 이동
-      return NextResponse.redirect(new URL("/dashboard", req.url))
+      // 로그인 상태에서 /login 접근 시, next가 있으면 우선 사용
+      const next = toSafeNextOrDefault(
+        req.nextUrl.searchParams.get("next") ?? undefined,
+        "/dashboard",
+      )
+      return NextResponse.redirect(new URL(next, req.url))
+    }
+
+    // 로그인 페이지 접근 시(미로그인)에도 next 쿼리가 있으면 서버에서 SSOT 쿠키를 설정
+    if (isAuthPath && !isLoggedIn) {
+      const rawNext = req.nextUrl.searchParams.get("next")
+      if (rawNext) {
+        const safeNext = toSafeNextOrDefault(rawNext)
+        const existing = req.cookies.get("return_to")?.value
+        if (existing !== safeNext) {
+          const resWithCookie = NextResponse.next()
+          resWithCookie.cookies.set("return_to", safeNext, {
+            path: "/",
+            maxAge: 600, // 10분
+            sameSite: "lax",
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+          })
+          return resWithCookie
+        }
+      }
     }
 
     return res
   } catch (err) {
-    console.error("Middleware error:", err)
-    const next = encodeURIComponent(req.nextUrl.pathname + req.nextUrl.search)
-    return NextResponse.redirect(new URL(`/login?next=${next}`, req.url))
+    // 오류 시에도 안전한 내부 경로만 보존하여 로그인으로 유도
+    const rawNext = req.nextUrl.pathname + req.nextUrl.search
+    const safeNext = toSafeNextOrDefault(rawNext)
+    const redirectUrl = new URL(`/login?next=${encodeURIComponent(safeNext)}`, req.url)
+    const redirectRes = NextResponse.redirect(redirectUrl)
+    redirectRes.cookies.set("return_to", safeNext, {
+      path: "/",
+      maxAge: 600, // 10분
+      sameSite: "lax",
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+    })
+    return redirectRes
   }
 }
 

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -13,8 +13,8 @@ interface AuthState {
   profile: ProfileMinimal | null
   isLoading: boolean
   error: string | null
-  loginWithKakao: (next?: string) => Promise<void>
-  loginWithGoogle: (next?: string) => Promise<void>
+  loginWithKakao: () => Promise<void>
+  loginWithGoogle: () => Promise<void>
   logout: () => Promise<void>
   checkAuth: () => Promise<void>
 }
@@ -25,19 +25,11 @@ export const useAuthStore = create<AuthState>((set) => ({
   isLoading: false,
   error: null,
 
-  loginWithKakao: async (next?: string) => {
+  loginWithKakao: async () => {
     try {
       set({ isLoading: true, error: null })
       const supabase = createClient()
       const origin = window.location.origin
-      // next는 쿠키로 전달 (redirectTo에는 동적 쿼리를 붙이지 않음)
-      if (typeof window !== "undefined") {
-        if (next) {
-          document.cookie = `return_to=${encodeURIComponent(next)}; Path=/; Max-Age=600; SameSite=Lax`
-        } else {
-          document.cookie = `return_to=; Path=/; Max-Age=0; SameSite=Lax`
-        }
-      }
       const redirectURL = `${origin}/api/auth/callback`
 
       await supabase.auth.signInWithOAuth({
@@ -51,19 +43,11 @@ export const useAuthStore = create<AuthState>((set) => ({
     }
   },
 
-  loginWithGoogle: async (next?: string) => {
+  loginWithGoogle: async () => {
     try {
       set({ isLoading: true, error: null })
       const supabase = createClient()
       const origin = window.location.origin
-      // next는 쿠키로 전달 (redirectTo에는 동적 쿼리를 붙이지 않음)
-      if (typeof window !== "undefined") {
-        if (next) {
-          document.cookie = `return_to=${encodeURIComponent(next)}; Path=/; Max-Age=600; SameSite=Lax`
-        } else {
-          document.cookie = `return_to=; Path=/; Max-Age=0; SameSite=Lax`
-        }
-      }
       const redirectURL = `${origin}/api/auth/callback`
 
       await supabase.auth.signInWithOAuth({


### PR DESCRIPTION
- WHAT:
- profile 레포/서비스 책임 분리 (users 테이블 조회 분리)
- profile 서비스 에러 처리 표준화 (wrapService)
- profile 레포 반환 타입 강화 (DB 타입 기반 Pick)
- login 플로우에서 next 인자 제거, 서버 return_to 쿠키로 SSOT 통일
- WHY:
- 레이어별 책임 명확화, 코드 재사용성/테스트 용이성 향상
- 에러 처리 일관성 확보 및 취약한 문자열 파싱 제거
- 컴파일 타임 안정성 강화
- 클라이언트 측 쿠키 쓰기 제거로 리디렉션 경합/누수 방지